### PR TITLE
Pass proc arg to pnet components

### DIFF
--- a/opal/mca/pmix/pmix3x/pmix/src/mca/pnet/base/pnet_base_fns.c
+++ b/opal/mca/pmix/pmix3x/pmix/src/mca/pnet/base/pnet_base_fns.c
@@ -164,7 +164,7 @@ pmix_status_t pmix_pnet_base_setup_fork(const pmix_proc_t *proc, char ***env)
 
     PMIX_LIST_FOREACH(active, &pmix_pnet_globals.actives, pmix_pnet_base_active_module_t) {
         if (NULL != active->module->setup_fork) {
-            if (PMIX_SUCCESS != (rc = active->module->setup_fork(nptr, env))) {
+            if (PMIX_SUCCESS != (rc = active->module->setup_fork(nptr, proc, env))) {
                 return rc;
             }
         }

--- a/opal/mca/pmix/pmix3x/pmix/src/mca/pnet/opa/pnet_opa.c
+++ b/opal/mca/pmix/pmix3x/pmix/src/mca/pnet/opa/pnet_opa.c
@@ -51,7 +51,9 @@ static pmix_status_t setup_app(pmix_nspace_t *nptr,
 static pmix_status_t setup_local_network(pmix_nspace_t *nptr,
                                          pmix_info_t info[],
                                          size_t ninfo);
-static pmix_status_t setup_fork(pmix_nspace_t *nptr, char ***env);
+static pmix_status_t setup_fork(pmix_nspace_t *nptr,
+                                const pmix_proc_t *proc,
+                                char ***env);
 static void child_finalized(pmix_peer_t *peer);
 static void local_app_finalized(char *nspace);
 
@@ -330,7 +332,9 @@ static pmix_status_t setup_local_network(pmix_nspace_t *nptr,
     return PMIX_SUCCESS;
 }
 
-static pmix_status_t setup_fork(pmix_nspace_t *nptr, char ***env)
+static pmix_status_t setup_fork(pmix_nspace_t *nptr,
+                                const pmix_proc_t *proc,
+                                char ***env)
 {
     pmix_kval_t *kv, *next;
 

--- a/opal/mca/pmix/pmix3x/pmix/src/mca/pnet/pnet.h
+++ b/opal/mca/pmix/pmix3x/pmix/src/mca/pnet/pnet.h
@@ -72,7 +72,9 @@ typedef pmix_status_t (*pmix_pnet_base_module_setup_local_net_fn_t)(pmix_nspace_
  * Give the local network library an opportunity to add any envars to the
  * environment of a local application process prior to fork/exec
  */
-typedef pmix_status_t (*pmix_pnet_base_module_setup_fork_fn_t)(pmix_nspace_t *nptr, char ***env);
+typedef pmix_status_t (*pmix_pnet_base_module_setup_fork_fn_t)(pmix_nspace_t *nptr,
+                                                               const pmix_proc_t *proc,
+                                                               char ***env);
 
 /**
  * Provide an opportunity for the local network library to cleanup when a


### PR DESCRIPTION
Pass the pmix_proc_t arg to pnet components in the setup_fork call so they can do things to setup that specific proc prior to launch. Provide an example where we retrieve the local rank of the proc.

Signed-off-by: Ralph Castain <rhc@open-mpi.org>