### PR TITLE
Cleanup and complete direct-launch PMIx debugger model

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -121,6 +121,7 @@ examples/debuggerd
 examples/dmodex
 examples/dynamic
 examples/fault
+examples/hello
 examples/launcher
 examples/pmi1client
 examples/probe

--- a/config/ltmain_nag_pthread.diff
+++ b/config/ltmain_nag_pthread.diff
@@ -8,7 +8,7 @@
  	if test -n "$inherited_linker_flags"; then
 -	  tmp_inherited_linker_flags=`$ECHO "$inherited_linker_flags" | $SED 's/-framework \([^ $]*\)/\1.ltframework/g'`
 +          case "$CC" in
-+            nagfor*)
++            *nagfor*)
 +	      tmp_inherited_linker_flags=`$ECHO "$inherited_linker_flags" | $SED 's/-framework \([^ $]*\)/\1.ltframework/g' | $SED 's/-pthread/-Wl,-pthread/g'`;;
 +            *)
 +	      tmp_inherited_linker_flags=`$ECHO "$inherited_linker_flags" | $SED 's/-framework \([^ $]*\)/\1.ltframework/g'`;;

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -44,7 +44,8 @@ EXAMPLES = \
 	 tool \
 	 alloc \
          probe \
-         target
+         target \
+         hello
 
 all: $(EXAMPLES)
 

--- a/examples/debugger.c
+++ b/examples/debugger.c
@@ -79,11 +79,18 @@ typedef struct {
     size_t ninfo;
 } myquery_data_t;
 
+/* define a structure for releasing when a given
+ * nspace terminates */
+typedef struct {
+    mylock_t lock;
+    char *nspace;
+    int exit_code;
+    bool exit_code_given;
+} myrel_t;
+
+
 static int attach_to_running_job(char *nspace);
-static mylock_t waiting_for_debugger, waiting_for_client;
 static pmix_proc_t myproc;
-static char dspace[PMIX_MAX_NSLEN+1];
-static char clientspace[PMIX_MAX_NSLEN+1];
 
 /* this is a callback function for the PMIx_Query
  * API. The query will callback with a status indicating
@@ -142,7 +149,7 @@ static void notification_fn(size_t evhdlr_registration_id,
 {
     /* this example doesn't do anything with default events */
     if (NULL != cbfunc) {
-        cbfunc(PMIX_EVENT_ACTION_COMPLETE, NULL, 0, NULL, NULL, cbdata);
+        cbfunc(PMIX_SUCCESS, NULL, 0, NULL, NULL, cbdata);
     }
 }
 
@@ -161,18 +168,51 @@ static void release_fn(size_t evhdlr_registration_id,
                        pmix_event_notification_cbfunc_fn_t cbfunc,
                        void *cbdata)
 {
+    myrel_t *lock;
+    pmix_status_t rc;
+    bool found;
+    int exit_code;
+    size_t n;
+    pmix_proc_t *affected = NULL;
+
+    /* find our return object */
+    lock = NULL;
+    found = false;
+    for (n=0; n < ninfo; n++) {
+        if (0 == strncmp(info[n].key, PMIX_EVENT_RETURN_OBJECT, PMIX_MAX_KEYLEN)) {
+            lock = (myrel_t*)info[n].value.data.ptr;
+            /* not every RM will provide an exit code, but check if one was given */
+        } else if (0 == strncmp(info[n].key, PMIX_EXIT_CODE, PMIX_MAX_KEYLEN)) {
+            exit_code = info[n].value.data.integer;
+            found = true;
+        } else if (0 == strncmp(info[n].key, PMIX_EVENT_AFFECTED_PROC, PMIX_MAX_KEYLEN)) {
+            affected = info[n].value.data.proc;
+        }
+    }
+    /* if the object wasn't returned, then that is an error */
+    if (NULL == lock) {
+        fprintf(stderr, "LOCK WASN'T RETURNED IN RELEASE CALLBACK\n");
+        /* let the event handler progress */
+        if (NULL != cbfunc) {
+            cbfunc(PMIX_SUCCESS, NULL, 0, NULL, NULL, cbdata);
+        }
+        return;
+    }
+
+    fprintf(stderr, "DEBUGGER NOTIFIED THAT JOB %s TERMINATED - AFFECTED %s\n", lock->nspace,
+            (NULL == affected) ? "NULL" : affected->nspace);
+
+    if (found) {
+        lock->exit_code = exit_code;
+        lock->exit_code_given = true;
+    }
+    DEBUG_WAKEUP_THREAD(&lock->lock);
+
     /* tell the event handler state machine that we are the last step */
     if (NULL != cbfunc) {
         cbfunc(PMIX_EVENT_ACTION_COMPLETE, NULL, 0, NULL, NULL, cbdata);
     }
-    /* if this was the debugger daemon, then flag it */
-    if (0 == strncmp(source->nspace, dspace, PMIX_MAX_NSLEN)) {
-        fprintf(stderr, "DEBUGGER DAEMON HAS EXITED\n");
-        DEBUG_WAKEUP_THREAD(&waiting_for_debugger);
-    } else if (0 == strncmp(source->nspace, clientspace, PMIX_MAX_NSLEN)) {
-        fprintf(stderr, "CLIENT JOB HAS EXITED\n");
-        DEBUG_WAKEUP_THREAD(&waiting_for_client);
-    }
+    return;
 }
 
 /* event handler registration is done asynchronously because it
@@ -196,13 +236,16 @@ static void evhandler_reg_callbk(pmix_status_t status,
     DEBUG_WAKEUP_THREAD(lock);
 }
 
-static pmix_status_t spawn_debugger(char *appspace)
+static pmix_status_t spawn_debugger(char *appspace, myrel_t *myrel)
 {
     pmix_status_t rc;
     pmix_info_t *dinfo;
     pmix_app_t *debugger;
     size_t dninfo;
     char cwd[1024];
+    char dspace[PMIX_MAX_NSLEN+1];
+    mylock_t mylock;
+    pmix_status_t code = PMIX_ERR_JOB_TERMINATED;
 
     /* setup the debugger */
     PMIX_APP_CREATE(debugger, 1);
@@ -225,11 +268,29 @@ static pmix_status_t spawn_debugger(char *appspace)
     fprintf(stderr, "Debugger: spawning %s\n", debugger[0].cmd);
     if (PMIX_SUCCESS != (rc = PMIx_Spawn(dinfo, dninfo, debugger, 1, dspace))) {
         fprintf(stderr, "Debugger daemons failed to launch with error: %s\n", PMIx_Error_string(rc));
+        PMIX_INFO_FREE(dinfo, dninfo);
+        PMIX_APP_FREE(debugger, 1);
+        return rc;
     }
     fprintf(stderr, "SPAWNED DEBUGGERD\n");
     /* cleanup */
     PMIX_INFO_FREE(dinfo, dninfo);
     PMIX_APP_FREE(debugger, 1);
+
+    /* register callback for when this job terminates */
+    myrel->nspace = strdup(dspace);
+    PMIX_INFO_CREATE(dinfo, 2);
+    PMIX_INFO_LOAD(&dinfo[0], PMIX_EVENT_RETURN_OBJECT, myrel, PMIX_POINTER);
+    /* only call me back when this specific job terminates */
+    PMIX_INFO_LOAD(&dinfo[1], PMIX_NSPACE, dspace, PMIX_STRING);
+
+    DEBUG_CONSTRUCT_LOCK(&mylock);
+    PMIx_Register_event_handler(&code, 1, dinfo, 2,
+                                release_fn, evhandler_reg_callbk, (void*)&mylock);
+    DEBUG_WAIT_THREAD(&mylock);
+    rc = mylock.status;
+    DEBUG_DESTRUCT_LOCK(&mylock);
+    PMIX_INFO_FREE(dinfo, 2);
 
     return rc;
 }
@@ -251,6 +312,7 @@ int main(int argc, char **argv)
     char cwd[1024];
     pmix_status_t code = PMIX_ERR_JOB_TERMINATED;
     mylock_t mylock;
+    myrel_t myrel, launcher_ready, dbrel;
     pid_t pid;
     pmix_envar_t envar;
     char *launchers[] = {
@@ -263,6 +325,8 @@ int main(int argc, char **argv)
     pmix_proc_t proc;
     bool found;
     pmix_data_array_t darray;
+    char *tmp;
+    char clientspace[PMIX_MAX_NSLEN+1];
 
     pid = getpid();
 
@@ -295,33 +359,25 @@ int main(int argc, char **argv)
     info = NULL;
     ninfo = 0;
 
-    DEBUG_CONSTRUCT_LOCK(&waiting_for_debugger);
-    DEBUG_CONSTRUCT_LOCK(&waiting_for_client);
-
     /* use the system connection first, if available */
     PMIX_INFO_CREATE(info, 1);
     PMIX_INFO_LOAD(&info[0], PMIX_CONNECT_SYSTEM_FIRST, NULL, PMIX_BOOL);
     /* init as a tool */
     if (PMIX_SUCCESS != (rc = PMIx_tool_init(&myproc, info, ninfo))) {
-        fprintf(stderr, "PMIx_tool_init failed: %d\n", rc);
+        fprintf(stderr, "PMIx_tool_init failed: %s(%d)\n", PMIx_Error_string(rc), rc);
         exit(rc);
     }
     PMIX_INFO_FREE(info, ninfo);
 
-    fprintf(stderr, "Tool ns %s rank %d pid %lu: Running\n", myproc.nspace, myproc.rank, (unsigned long)pid);
+    fprintf(stderr, "Debugger ns %s rank %d pid %lu: Running\n", myproc.nspace, myproc.rank, (unsigned long)pid);
+
+    /* construct the debugger termination release */
+    DEBUG_CONSTRUCT_LOCK(&dbrel.lock);
 
     /* register a default event handler */
     DEBUG_CONSTRUCT_LOCK(&mylock);
     PMIx_Register_event_handler(NULL, 0, NULL, 0,
                                 notification_fn, evhandler_reg_callbk, (void*)&mylock);
-    DEBUG_WAIT_THREAD(&mylock);
-    DEBUG_DESTRUCT_LOCK(&mylock);
-
-    /* register another handler specifically for when the debugger
-     * job completes */
-    DEBUG_CONSTRUCT_LOCK(&mylock);
-    PMIx_Register_event_handler(&code, 1, NULL, 0,
-                                release_fn, evhandler_reg_callbk, (void*)&mylock);
     DEBUG_WAIT_THREAD(&mylock);
     DEBUG_DESTRUCT_LOCK(&mylock);
 
@@ -346,6 +402,27 @@ int main(int argc, char **argv)
         }
     }
     if (found) {
+        /* register to receive the "launcher-ready" event telling us
+         * that the launcher is ready for us to connect to it */
+        DEBUG_CONSTRUCT_LOCK(&mylock);
+        code = PMIX_LAUNCHER_READY;
+        /* pass a lock object to release us when the launcher is ready */
+        DEBUG_CONSTRUCT_LOCK(&launcher_ready.lock);
+        PMIX_INFO_CREATE(info, 2);
+        PMIX_INFO_LOAD(&info[0], PMIX_EVENT_RETURN_OBJECT, &launcher_ready, PMIX_POINTER);
+        PMIX_INFO_LOAD(&info[1], PMIX_EVENT_HDLR_NAME, "LAUNCHER-READY", PMIX_STRING);
+        PMIx_Register_event_handler(&code, 1, info, 2,
+                                    release_fn, evhandler_reg_callbk, (void*)&mylock);
+        DEBUG_WAIT_THREAD(&mylock);
+        if (PMIX_SUCCESS != mylock.status) {
+            rc = mylock.status;
+            DEBUG_DESTRUCT_LOCK(&mylock);
+            PMIX_INFO_FREE(info, 2);
+            goto done;
+        }
+        DEBUG_DESTRUCT_LOCK(&mylock);
+        PMIX_INFO_FREE(info, 2);
+
         /* we are using an intermediate launcher - we will use the
          * reference server to start it, but tell it to wait after
          * launch for directive prior to spawning the application */
@@ -364,22 +441,47 @@ int main(int argc, char **argv)
         ninfo = 5;
         PMIX_INFO_CREATE(info, ninfo);
         PMIX_INFO_LOAD(&info[0], PMIX_MAPBY, "slot", PMIX_STRING);  // map by slot
-        PMIX_ENVAR_LOAD(&envar, "PMIX_LAUNCHER_PAUSE_FOR_TOOL", "1", ':');
+        asprintf(&tmp, "%s:%d", myproc.nspace, myproc.rank);
+        PMIX_ENVAR_LOAD(&envar, "PMIX_LAUNCHER_PAUSE_FOR_TOOL", tmp, ':');
+        free(tmp);
         PMIX_INFO_LOAD(&info[1], PMIX_SET_ENVAR, &envar, PMIX_ENVAR);  // launcher is to wait for directives
         PMIX_ENVAR_DESTRUCT(&envar);
-        PMIX_INFO_LOAD(&info[2], PMIX_FWD_STDOUT, NULL, PMIX_BOOL);  // forward stdout to me
-        PMIX_INFO_LOAD(&info[3], PMIX_FWD_STDERR, NULL, PMIX_BOOL);  // forward stderr to me
+        cospawn = false;
+        PMIX_INFO_LOAD(&info[2], PMIX_FWD_STDOUT, &cospawn, PMIX_BOOL);  // forward stdout to me
+        PMIX_INFO_LOAD(&info[3], PMIX_FWD_STDERR, &cospawn, PMIX_BOOL);  // forward stderr to me
         PMIX_INFO_LOAD(&info[4], PMIX_NOTIFY_COMPLETION, NULL, PMIX_BOOL); // notify us when the job completes
 
         /* spawn the job - the function will return when the launcher
-         * has been launched */
+         * has been launched. Note that this doesn't tell us anything
+         * about the launcher's state - it just means that the launcher
+         * has been fork/exec'd */
         fprintf(stderr, "Debugger: spawning %s\n", app[0].cmd);
-        if (PMIX_SUCCESS != (rc = PMIx_Spawn(info, ninfo, app, napps, clientspace))) {
+        rc = PMIx_Spawn(info, ninfo, app, napps, clientspace);
+        PMIX_INFO_FREE(info, ninfo);
+        PMIX_APP_FREE(app, napps);
+        if (PMIX_SUCCESS != rc) {
             fprintf(stderr, "Application failed to launch with error: %s(%d)\n", PMIx_Error_string(rc), rc);
             goto done;
         }
-        PMIX_INFO_FREE(info, ninfo);
-        PMIX_APP_FREE(app, napps);
+        fprintf(stderr, "Spawn complete\n\n");
+
+        /* wait here for the launcher to declare itself ready */
+        DEBUG_WAIT_THREAD(&launcher_ready.lock);
+        DEBUG_DESTRUCT_LOCK(&launcher_ready.lock);
+
+
+        /* transfer our connection to the spawned launcher - by making it our
+         * server, we can query it for information about the job it launched */
+        PMIX_INFO_CREATE(info, 2);
+        PMIX_INFO_LOAD(&info[0], PMIX_SERVER_NSPACE, clientspace, PMIX_STRING);  // find rendezvous info by nspace
+        PMIX_INFO_LOAD(&info[1], PMIX_RECONNECT_SERVER, NULL, PMIX_BOOL);  // we are reconnecting
+        rc = PMIx_tool_connect_to_server(NULL, info, 2);
+        PMIX_INFO_FREE(info, 2);
+        if (PMIX_SUCCESS != rc) {
+            fprintf(stderr, "Failed to connect to %s server: %s(%d)\n", argv[1], PMIx_Error_string(rc), rc);
+            goto done;
+        }
+        fprintf(stderr, "Connection completed\n");
         /* send the launch directives */
         ninfo = 3;
         PMIX_INFO_CREATE(info, ninfo);
@@ -400,7 +502,7 @@ int main(int argc, char **argv)
 
         PMIX_INFO_LOAD(&info[2], PMIX_DEBUG_JOB_DIRECTIVES, &darray, PMIX_DATA_ARRAY);
         /* provide a few app-level directives */
-    //    PMIX_INFO_LOAD(&info[3], PMIX_DEBUG_APP_DIRECTIVES, &darray, PMIX_DATA_ARRAY);
+        PMIX_INFO_LOAD(&info[3], PMIX_DEBUG_APP_DIRECTIVES, &darray, PMIX_DATA_ARRAY);
 
         fprintf(stderr, "[%s:%u%lu] Sending release\n", myproc.nspace, myproc.rank, (unsigned long)pid);
         PMIx_Notify_event(PMIX_LAUNCH_DIRECTIVE,
@@ -482,8 +584,8 @@ int main(int argc, char **argv)
             napps = 1;
             PMIX_APP_CREATE(app, napps);
             /* setup the executable */
-            app[0].cmd = strdup("client");
-            PMIX_ARGV_APPEND(rc, app[0].argv, "./client");
+            app[0].cmd = strdup("hello");
+            PMIX_ARGV_APPEND(rc, app[0].argv, "./hello");
             getcwd(cwd, 1024);  // point us to our current directory
             app[0].cwd = strdup(cwd);
             app[0].maxprocs = 2;
@@ -563,10 +665,10 @@ int main(int argc, char **argv)
              *     pmix_proc_state_t state;
              */
             fprintf(stderr, "Received %d array elements\n", (int)myquery_data.info[0].value.data.darray->size);
-            goto done;
 
             /* now launch the debugger daemons */
-            if (PMIX_SUCCESS != (rc = spawn_debugger(clientspace))) {
+            if (PMIX_SUCCESS != (rc = spawn_debugger(clientspace, &dbrel))) {
+                fprintf(stderr, "Debugger daemons failed to spawn: %s\n", PMIx_Error_string(rc));
                 goto done;
             }
         }
@@ -574,11 +676,12 @@ int main(int argc, char **argv)
 
   rundebugger:
     /* this is where a debugger tool would wait until the debug operation is complete */
-    DEBUG_WAIT_THREAD(&waiting_for_debugger);
-    DEBUG_WAIT_THREAD(&waiting_for_client);
+    DEBUG_WAIT_THREAD(&dbrel.lock);
+    DEBUG_WAIT_THREAD(&myrel.lock);
 
   done:
-    DEBUG_DESTRUCT_LOCK(&waiting_for_debugger);
+    DEBUG_DESTRUCT_LOCK(&myrel.lock);
+    DEBUG_DESTRUCT_LOCK(&dbrel.lock);
     PMIx_tool_finalize();
 
     return(rc);

--- a/examples/debuggerd.c
+++ b/examples/debuggerd.c
@@ -29,19 +29,66 @@
 #include <stdlib.h>
 #include <unistd.h>
 #include <time.h>
+#include <pthread.h>
 
 #include <pmix_tool.h>
+
+typedef struct {
+    pthread_mutex_t mutex;
+    pthread_cond_t cond;
+    volatile bool active;
+    pmix_status_t status;
+} mylock_t;
+
+#define DEBUG_CONSTRUCT_LOCK(l)                     \
+    do {                                            \
+        pthread_mutex_init(&(l)->mutex, NULL);      \
+        pthread_cond_init(&(l)->cond, NULL);        \
+        (l)->active = true;                         \
+        (l)->status = PMIX_SUCCESS;                 \
+    } while(0)
+
+#define DEBUG_DESTRUCT_LOCK(l)              \
+    do {                                    \
+        pthread_mutex_destroy(&(l)->mutex); \
+        pthread_cond_destroy(&(l)->cond);   \
+    } while(0)
+
+#define DEBUG_WAIT_THREAD(lck)                                      \
+    do {                                                            \
+        pthread_mutex_lock(&(lck)->mutex);                          \
+        while ((lck)->active) {                                     \
+            pthread_cond_wait(&(lck)->cond, &(lck)->mutex);         \
+        }                                                           \
+        pthread_mutex_unlock(&(lck)->mutex);                        \
+    } while(0)
+
+#define DEBUG_WAKEUP_THREAD(lck)                        \
+    do {                                                \
+        pthread_mutex_lock(&(lck)->mutex);              \
+        (lck)->active = false;                          \
+        pthread_cond_broadcast(&(lck)->cond);           \
+        pthread_mutex_unlock(&(lck)->mutex);            \
+    } while(0)
 
 /* define a structure for collecting returned
  * info from a query */
 typedef struct {
-    volatile bool active;
+    mylock_t lock;
+    pmix_status_t status;
     pmix_info_t *info;
     size_t ninfo;
 } myquery_data_t;
 
+/* define a structure for releasing when a given
+ * nspace terminates */
+typedef struct {
+    mylock_t lock;
+    char *nspace;
+    int exit_code;
+    bool exit_code_given;
+} myrel_t;
 
-static volatile bool waiting_for_debugger = true;
 static pmix_proc_t myproc;
 
 /* this is a callback function for the PMIx_Query
@@ -65,6 +112,8 @@ static void cbfunc(pmix_status_t status,
     myquery_data_t *mq = (myquery_data_t*)cbdata;
     size_t n;
 
+    mq->status = status;
+
     /* save the returned info - it will be
      * released in the release_fn */
     if (0 < ninfo) {
@@ -82,7 +131,7 @@ static void cbfunc(pmix_status_t status,
     }
 
     /* release the block */
-    mq->active = false;
+    DEBUG_WAKEUP_THREAD(&mq->lock);
 }
 
 /* this is the event notification function we pass down below
@@ -98,8 +147,68 @@ static void notification_fn(size_t evhdlr_registration_id,
                             void *cbdata)
 {
     if (NULL != cbfunc) {
+        cbfunc(PMIX_SUCCESS, NULL, 0, NULL, NULL, cbdata);
+    }
+}
+
+/* this is an event notification function that we explicitly request
+ * be called when the PMIX_ERR_JOB_TERMINATED notification is issued.
+ * We could catch it in the general event notification function and test
+ * the status to see if it was "job terminated", but it often is simpler
+ * to declare a use-specific notification callback point. In this case,
+ * we are asking to know whenever a job terminates, and we will then
+ * know we can exit */
+static void release_fn(size_t evhdlr_registration_id,
+                       pmix_status_t status,
+                       const pmix_proc_t *source,
+                       pmix_info_t info[], size_t ninfo,
+                       pmix_info_t results[], size_t nresults,
+                       pmix_event_notification_cbfunc_fn_t cbfunc,
+                       void *cbdata)
+{
+    myrel_t *lock;
+    pmix_status_t rc;
+    bool found;
+    int exit_code;
+    size_t n;
+    pmix_proc_t *affected = NULL;
+
+    /* find our return object */
+    lock = NULL;
+    found = false;
+    for (n=0; n < ninfo; n++) {
+        if (0 == strncmp(info[n].key, PMIX_EVENT_RETURN_OBJECT, PMIX_MAX_KEYLEN)) {
+            lock = (myrel_t*)info[n].value.data.ptr;
+            /* not every RM will provide an exit code, but check if one was given */
+        } else if (0 == strncmp(info[n].key, PMIX_EXIT_CODE, PMIX_MAX_KEYLEN)) {
+            exit_code = info[n].value.data.integer;
+            found = true;
+        } else if (0 == strncmp(info[n].key, PMIX_EVENT_AFFECTED_PROC, PMIX_MAX_KEYLEN)) {
+            affected = info[n].value.data.proc;
+        }
+    }
+    /* if the object wasn't returned, then that is an error */
+    if (NULL == lock) {
+        fprintf(stderr, "LOCK WASN'T RETURNED IN RELEASE CALLBACK\n");
+        /* let the event handler progress */
+        if (NULL != cbfunc) {
+            cbfunc(PMIX_SUCCESS, NULL, 0, NULL, NULL, cbdata);
+        }
+        return;
+    }
+
+    /* tell the event handler state machine that we are the last step */
+    if (NULL != cbfunc) {
         cbfunc(PMIX_EVENT_ACTION_COMPLETE, NULL, 0, NULL, NULL, cbdata);
     }
+    fprintf(stderr, "DEBUGGER DAEMON NOTIFIED THAT JOB %s TERMINATED - AFFECTED %s\n", lock->nspace,
+            (NULL == affected) ? "NULL" : affected->nspace);
+
+    if (found) {
+        lock->exit_code = exit_code;
+        lock->exit_code_given = true;
+    }
+    DEBUG_WAKEUP_THREAD(&lock->lock);
 }
 
 /* event handler registration is done asynchronously because it
@@ -113,13 +222,14 @@ static void evhandler_reg_callbk(pmix_status_t status,
                                  size_t evhandler_ref,
                                  void *cbdata)
 {
-    volatile int *active = (volatile int*)cbdata;
+    mylock_t *lock = (mylock_t*)cbdata;
 
     if (PMIX_SUCCESS != status) {
         fprintf(stderr, "Client %s:%d EVENT HANDLER REGISTRATION FAILED WITH STATUS %d, ref=%lu\n",
                    myproc.nspace, myproc.rank, status, (unsigned long)evhandler_ref);
     }
-    *active = status;
+    lock->status = status;
+    DEBUG_WAKEUP_THREAD(lock);
 }
 
 int main(int argc, char **argv)
@@ -129,47 +239,107 @@ int main(int argc, char **argv)
     pmix_proc_t proc;
     pmix_info_t *info;
     size_t ninfo;
-    volatile int active;
     pmix_query_t *query;
     size_t nq, n;
     myquery_data_t myquery_data;
     pid_t pid;
+    pmix_status_t code = PMIX_ERR_JOB_TERMINATED;
+    mylock_t mylock;
+    myrel_t myrel;
+    uint16_t localrank;
+    char *target = NULL;
 
     pid = getpid();
-fprintf(stderr, "DEBUGGER DAEMON STARTED: %lu\n", (unsigned long)pid);
 
     /* init us - since we were launched by the RM, our connection info
      * will have been provided at startup. */
     if (PMIX_SUCCESS != (rc = PMIx_tool_init(&myproc, NULL, 0))) {
-        fprintf(stderr, "Debugger daemon ns %s rank %d: PMIx_tool_init failed: %d\n", myproc.nspace, myproc.rank, rc);
+        fprintf(stderr, "Debugger daemon: PMIx_tool_init failed: %d\n", rc);
         exit(0);
     }
     fprintf(stderr, "Debugger daemon ns %s rank %d pid %lu: Running\n", myproc.nspace, myproc.rank, (unsigned long)pid);
 
 
     /* register our default event handler */
-    active = -1;
+    DEBUG_CONSTRUCT_LOCK(&mylock);
     PMIx_Register_event_handler(NULL, 0, NULL, 0,
-                                notification_fn, evhandler_reg_callbk, (void*)&active);
-    while (-1 == active) {
-        usleep(10);
+                                notification_fn, evhandler_reg_callbk, (void*)&mylock);
+    DEBUG_WAIT_THREAD(&mylock);
+    if (PMIX_SUCCESS != mylock.status) {
+        rc = mylock.status;
+        DEBUG_DESTRUCT_LOCK(&mylock);
+        goto done;
     }
-    if (0 != active) {
-        exit(active);
-    }
+    DEBUG_DESTRUCT_LOCK(&mylock);
 
-    /* get the nspace of the job we are to debug */
-    (void)strncpy(proc.nspace, myproc.nspace, PMIX_MAX_NSLEN);
+    /* get the nspace of the job we are to debug - it will be in our JOB info */
+    PMIX_PROC_CONSTRUCT(&proc);
+    (void)strncpy(proc.nspace, myproc.nspace, PMIX_MAX_KEYLEN);
     proc.rank = PMIX_RANK_WILDCARD;
     if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, PMIX_DEBUG_JOB, NULL, 0, &val))) {
-        fprintf(stderr, "[%s:%d:%lu] Failed to get job being debugged - error %d\n", myproc.nspace, myproc.rank, (unsigned long)pid, rc);
+        fprintf(stderr, "[%s:%d:%lu] Failed to get job being debugged - error %s\n",
+                myproc.nspace, myproc.rank,
+                (unsigned long)pid, PMIx_Error_string(rc));
+        goto done;
+    }
+    if (NULL == val || PMIX_STRING != val->type || NULL == val->data.string) {
+        fprintf(stderr, "[%s:%d:%lu] Failed to get job being debugged - NULL data returned\n",
+                myproc.nspace, myproc.rank, (unsigned long)pid);
+        goto done;
+    }
+    /* save it for later */
+    target = strdup(val->data.string);
+    PMIX_VALUE_RELEASE(val);
+
+    fprintf(stderr, "[%s:%d:%lu] Debugging %s\n", myproc.nspace, myproc.rank,
+            (unsigned long)pid, target);
+
+    /* get my local rank so I can determine which local proc is "mine"
+     * to debug */
+    val = NULL;
+    if (PMIX_SUCCESS != (rc = PMIx_Get(&myproc, PMIX_LOCAL_RANK, NULL, 0, &val))) {
+        fprintf(stderr, "[%s:%d:%lu] Failed to get my local rank - error %s\n",
+                myproc.nspace, myproc.rank,
+                (unsigned long)pid, PMIx_Error_string(rc));
         goto done;
     }
     if (NULL == val) {
-        fprintf(stderr, "Got NULL return\n");
+        fprintf(stderr, "[%s:%d:%lu] Failed to get my local rank - NULL data returned\n",
+                myproc.nspace, myproc.rank, (unsigned long)pid);
         goto done;
     }
-    fprintf(stderr, "[%s:%d:%lu] Debugging %s\n", myproc.nspace, myproc.rank, (unsigned long)pid, val->data.string);
+    if (PMIX_UINT16 != val->type) {
+        fprintf(stderr, "[%s:%d:%lu] Failed to get my local rank - returned wrong type %s\n",
+                myproc.nspace, myproc.rank, (unsigned long)pid, PMIx_Data_type_string(val->type));
+        goto done;
+    }
+    /* save the data */
+    localrank = val->data.uint16;
+    PMIX_VALUE_RELEASE(val);
+    fprintf(stderr, "[%s:%d:%lu] my local rank %d\n", myproc.nspace, myproc.rank,
+            (unsigned long)pid, (int)localrank);
+
+    /* register another handler specifically for when the target
+     * job completes */
+    DEBUG_CONSTRUCT_LOCK(&myrel.lock);
+    myrel.nspace = strdup(proc.nspace);
+    PMIX_INFO_CREATE(info, 2);
+    PMIX_INFO_LOAD(&info[0], PMIX_EVENT_RETURN_OBJECT, &myrel, PMIX_POINTER);
+    /* only call me back when this specific job terminates */
+    PMIX_INFO_LOAD(&info[1], PMIX_NSPACE, target, PMIX_STRING);
+
+    DEBUG_CONSTRUCT_LOCK(&mylock);
+    PMIx_Register_event_handler(&code, 1, info, 2,
+                                release_fn, evhandler_reg_callbk, (void*)&mylock);
+    DEBUG_WAIT_THREAD(&mylock);
+    if (PMIX_SUCCESS != mylock.status) {
+        rc = mylock.status;
+        DEBUG_DESTRUCT_LOCK(&mylock);
+        PMIX_INFO_FREE(info, 2);
+        goto done;
+    }
+    DEBUG_DESTRUCT_LOCK(&mylock);
+    PMIX_INFO_FREE(info, 2);
 
     /* get our local proctable - for scalability reasons, we don't want to
      * have our "root" debugger process get the proctable for everybody and
@@ -180,47 +350,55 @@ fprintf(stderr, "DEBUGGER DAEMON STARTED: %lu\n", (unsigned long)pid);
     PMIX_ARGV_APPEND(rc, query[0].keys, PMIX_QUERY_LOCAL_PROC_TABLE);
     query[0].nqual = 1;
     PMIX_INFO_CREATE(query[0].qualifiers, 1);
-    PMIX_INFO_LOAD(&query[0].qualifiers[0], PMIX_NSPACE, val->data.string, PMIX_STRING);  // the nspace we are enquiring about
+    PMIX_INFO_LOAD(&query[0].qualifiers[0], PMIX_NSPACE, target, PMIX_STRING);  // the nspace we are enquiring about
     /* setup the caddy to retrieve the data */
+    DEBUG_CONSTRUCT_LOCK(&myquery_data.lock);
     myquery_data.info = NULL;
     myquery_data.ninfo = 0;
-    myquery_data.active = true;
     /* execute the query */
     if (PMIX_SUCCESS != (rc = PMIx_Query_info_nb(query, nq, cbfunc, (void*)&myquery_data))) {
         fprintf(stderr, "PMIx_Query_info failed: %d\n", rc);
         goto done;
     }
-    while (myquery_data.active) {
-        usleep(10);
+    DEBUG_WAIT_THREAD(&myquery_data.lock);
+    DEBUG_DESTRUCT_LOCK(&myquery_data.lock);
+    PMIX_QUERY_FREE(query, nq);
+    if (PMIX_SUCCESS != myquery_data.status) {
+        rc = myquery_data.status;
+        goto done;
     }
+
     fprintf(stderr, "[%s:%d:%lu] Local proctable received\n", myproc.nspace, myproc.rank, (unsigned long)pid);
 
 
     /* now that we have the proctable for our local processes, we can do our
      * magic debugger stuff and attach to them. We then send a "release" event
      * to them - i.e., it's the equivalent to setting the MPIR breakpoint. We
-     * do this with the event notification system */
-    (void)strncpy(proc.nspace, val->data.string, PMIX_MAX_NSLEN);
+     * do this with the event notification system. For this example, we just
+     * send it to all local procs of the job being debugged */
+    (void)strncpy(proc.nspace, target, PMIX_MAX_NSLEN);
     proc.rank = PMIX_RANK_WILDCARD;
-    /* we send the notification to just the local procs of the job being debugged */
     ninfo = 2;
     PMIX_INFO_CREATE(info, ninfo);
     PMIX_INFO_LOAD(&info[0], PMIX_EVENT_CUSTOM_RANGE, &proc, PMIX_PROC);  // deliver to the target nspace
     PMIX_INFO_LOAD(&info[1], PMIX_EVENT_NON_DEFAULT, NULL, PMIX_BOOL);  // deliver to the target nspace
-    fprintf(stderr, "[%s:%u%lu] Sending release\n", myproc.nspace, myproc.rank, (unsigned long)pid);
-    PMIx_Notify_event(PMIX_ERR_DEBUGGER_RELEASE,
-                      NULL, PMIX_RANGE_LOCAL,
-                      info, ninfo, NULL, NULL);
-
-    /* do some debugger magic */
-    n = 0;
-    fprintf(stderr, "[%s:%u:%lu] Hanging around awhile, doing debugger magic\n", myproc.nspace, myproc.rank, (unsigned long)pid);
-    while (n < 5) {
-        usleep(1000);
-        ++n;
+    fprintf(stderr, "[%s:%u:%lu] Sending release\n", myproc.nspace, myproc.rank, (unsigned long)pid);
+    rc = PMIx_Notify_event(PMIX_ERR_DEBUGGER_RELEASE,
+                           NULL, PMIX_RANGE_LOCAL,
+                           info, ninfo, NULL, NULL);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "%s[%s:%u:%lu] Sending release failed with error %s(%d)\n",
+                myproc.nspace, myproc.rank, (unsigned long)pid, PMIx_Error_string(rc), rc);
+        goto done;
     }
 
+    /* do some debugger magic while waiting for the job to terminate */
+    DEBUG_WAIT_THREAD(&myrel.lock);
+
   done:
+    if (NULL != target) {
+        free(target);
+    }
     /* finalize us */
     fprintf(stderr, "Debugger daemon ns %s rank %d pid %lu: Finalizing\n", myproc.nspace, myproc.rank, (unsigned long)pid);
     if (PMIX_SUCCESS != (rc = PMIx_Finalize(NULL, 0))) {

--- a/examples/hello.c
+++ b/examples/hello.c
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2004-2010 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2011 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2006-2013 Los Alamos National Security, LLC.
+ *                         All rights reserved.
+ * Copyright (c) 2009-2012 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2011      Oak Ridge National Labs.  All rights reserved.
+ * Copyright (c) 2013-2018 Intel, Inc. All rights reserved.
+ * Copyright (c) 2015      Mellanox Technologies, Inc.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ */
+
+#define _GNU_SOURCE
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+#include <pmix.h>
+
+static pmix_proc_t myproc;
+
+int main(int argc, char **argv)
+{
+    pmix_status_t rc;
+    pid_t pid;
+    char hostname[1024];
+    pmix_value_t *val;
+    uint16_t localrank;
+
+    pid = getpid();
+    gethostname(hostname, 1024);
+
+    /* init us - note that the call to "init" includes the return of
+     * any job-related info provided by the RM. This includes any
+     * debugger flag instructing us to stop-in-init. If such a directive
+     * is included, then the process will be stopped in this call until
+     * the "debugger release" notification arrives */
+    if (PMIX_SUCCESS != (rc = PMIx_Init(&myproc, NULL, 0))) {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Init failed: %s\n",
+                myproc.nspace, myproc.rank, PMIx_Error_string(rc));
+        exit(0);
+    }
+    /* get our local rank */
+    if (PMIX_SUCCESS != (rc = PMIx_Get(&myproc, PMIX_LOCAL_RANK, NULL, 0, &val))) {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Get local rank failed: %s\n",
+                myproc.nspace, myproc.rank, PMIx_Error_string(rc));
+        goto done;
+    }
+    localrank = val->data.uint16;
+    PMIX_VALUE_RELEASE(val);
+
+    fprintf(stderr, "Client ns %s rank %d pid %lu: Running on host %s localrank %d\n",
+            myproc.nspace, myproc.rank, (unsigned long)pid, hostname , (int)localrank);
+
+  done:
+    /* finalize us */
+    fprintf(stderr, "Client ns %s rank %d: Finalizing\n", myproc.nspace, myproc.rank);
+    if (PMIX_SUCCESS != (rc = PMIx_Finalize(NULL, 0))) {
+        fprintf(stderr, "Client ns %s rank %d:PMIx_Finalize failed: %s\n",
+                myproc.nspace, myproc.rank, PMIx_Error_string(rc));
+    } else {
+        fprintf(stderr, "Client ns %s rank %d:PMIx_Finalize successfully completed\n", myproc.nspace, myproc.rank);
+    }
+    fflush(stderr);
+    return(0);
+}

--- a/opal/include/opal/constants.h
+++ b/opal/include/opal/constants.h
@@ -98,7 +98,8 @@ enum {
     OPAL_ERR_HEARTBEAT_ALERT                = (OPAL_ERR_BASE - 67),
     OPAL_ERR_FILE_ALERT                     = (OPAL_ERR_BASE - 68),
     OPAL_ERR_MODEL_DECLARED                 = (OPAL_ERR_BASE - 69),
-    OPAL_PMIX_LAUNCH_DIRECTIVE              = (OPAL_ERR_BASE - 70)
+    OPAL_PMIX_LAUNCH_DIRECTIVE              = (OPAL_ERR_BASE - 70),
+    OPAL_PMIX_LAUNCHER_READY                = (OPAL_ERR_BASE - 71)
 };
 
 #define OPAL_ERR_MAX                (OPAL_ERR_BASE - 100)

--- a/opal/mca/btl/tcp/btl_tcp.h
+++ b/opal/mca/btl/tcp/btl_tcp.h
@@ -15,7 +15,7 @@
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2014-2015 Los Alamos National Security, LLC. All rights
  *                         reserved.
- * Copyright (c) 2017      Intel, Inc. All rights reserved.
+ * Copyright (c) 2017-2018 Intel, Inc. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -168,7 +168,10 @@ struct mca_btl_tcp_module_t {
 #if 0
     int                tcp_ifindex; /**< BTL interface index */
 #endif
-    struct sockaddr_storage tcp_ifaddr; /**< BTL interface address */
+    struct sockaddr_storage tcp_ifaddr; /**< First IPv4 address discovered for this interface, bound as sending address for this BTL */
+#if OPAL_ENABLE_IPV6
+    struct sockaddr_storage tcp_ifaddr_6; /**< First IPv6 address discovered for this interface, bound as sending address for this BTL  */
+#endif
     uint32_t           tcp_ifmask;  /**< BTL interface netmask */
 
     opal_mutex_t       tcp_endpoints_mutex;

--- a/opal/mca/btl/tcp/btl_tcp_component.c
+++ b/opal/mca/btl/tcp/btl_tcp_component.c
@@ -16,7 +16,7 @@
  * Copyright (c) 2012-2015 Los Alamos National Security, LLC.  All rights
  *                         reserved.
  * Copyright (c) 2013-2015 NVIDIA Corporation.  All rights reserved.
- * Copyright (c) 2014-2017 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2014-2018 Intel, Inc. All rights reserved.
  * Copyright (c) 2014-2017 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
@@ -511,6 +511,17 @@ static int mca_btl_tcp_create(int if_kindex, const char* if_name)
         btl->tcp_send_handler = 0;
 #endif
 
+       struct sockaddr_storage addr;
+       opal_ifkindextoaddr(if_kindex, (struct sockaddr*) &addr,
+                                          sizeof (struct sockaddr_storage));
+#if OPAL_ENABLE_IPV6
+        if (addr.ss_family == AF_INET6) {
+            btl->tcp_ifaddr_6 =  addr;
+        }
+#endif
+        if (addr.ss_family == AF_INET) {
+           btl->tcp_ifaddr = addr;
+        }
         /* allow user to specify interface bandwidth */
         sprintf(param, "bandwidth_%s", if_name);
         mca_btl_tcp_param_register_uint(param, NULL, btl->super.btl_bandwidth, OPAL_INFO_LVL_5, &btl->super.btl_bandwidth);

--- a/opal/mca/btl/tcp/btl_tcp_endpoint.c
+++ b/opal/mca/btl/tcp/btl_tcp_endpoint.c
@@ -11,7 +11,7 @@
  *                         All rights reserved.
  * Copyright (c) 2007-2008 Sun Microsystems, Inc.  All rights reserved.
  * Copyright (c) 2013      Cisco Systems, Inc.  All rights reserved.
- * Copyright (c) 2014-2017 Intel, Inc. All rights reserved.
+ * Copyright (c) 2014-2018 Intel, Inc. All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
@@ -718,6 +718,34 @@ static int mca_btl_tcp_endpoint_start_connect(mca_btl_base_endpoint_t* btl_endpo
     /* start the connect - will likely fail with EINPROGRESS */
     mca_btl_tcp_proc_tosocks(btl_endpoint->endpoint_addr, &endpoint_addr);
 
+    /* Bind the socket to one of the addresses associated with
+     * this btl module.  This sets the source IP to one of the
+     * addresses shared in modex, so that the destination rank
+     * can properly pair btl modules, even in cases where Linux
+     * might do something unexpected with routing */
+    opal_socklen_t sockaddr_addrlen = sizeof(struct sockaddr_storage);
+    if (endpoint_addr.ss_family == AF_INET) {
+        assert(NULL != &btl_endpoint->endpoint_btl->tcp_ifaddr);
+        if (bind(btl_endpoint->endpoint_sd, (struct sockaddr*) &btl_endpoint->endpoint_btl->tcp_ifaddr,
+                 sockaddr_addrlen) < 0) {
+            BTL_ERROR(("bind() failed: %s (%d)", strerror(opal_socket_errno), opal_socket_errno));
+
+            CLOSE_THE_SOCKET(btl_endpoint->endpoint_sd);
+            return OPAL_ERROR;
+        }
+    }
+#if OPAL_ENABLE_IPV6
+    if (endpoint_addr.ss_family == AF_INET6) {
+        assert(NULL != &btl_endpoint->endpoint_btl->tcp_ifaddr_6);
+        if (bind(btl_endpoint->endpoint_sd, (struct sockaddr*) &btl_endpoint->endpoint_btl->tcp_ifaddr_6,
+            sockaddr_addrlen) < 0) {
+            BTL_ERROR(("bind() failed: %s (%d)", strerror(opal_socket_errno), opal_socket_errno));
+
+            CLOSE_THE_SOCKET(btl_endpoint->endpoint_sd);
+            return OPAL_ERROR;
+        }
+    }
+#endif
     opal_output_verbose(10, opal_btl_base_framework.framework_output,
                         "btl: tcp: attempting to connect() to %s address %s on port %d",
                         OPAL_NAME_PRINT(btl_endpoint->endpoint_proc->proc_opal->proc_name),

--- a/opal/mca/btl/tcp/btl_tcp_proc.c
+++ b/opal/mca/btl/tcp/btl_tcp_proc.c
@@ -11,7 +11,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2008-2010 Oracle and/or its affiliates.  All rights reserved
- * Copyright (c) 2013-2017 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2013-2018 Intel, Inc. All rights reserved.
  * Copyright (c) 2014-2016 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2015-2016 Los Alamos National Security, LLC. All rights
@@ -486,7 +486,7 @@ int mca_btl_tcp_proc_insert( mca_btl_tcp_proc_t* btl_proc,
         }
 
         /*
-         * in case the peer address has all intended connections,
+         * in case the peer address has created all intended connections,
          * mark the complete peer interface as 'not available'
          */
         if(endpoint_addr->addr_inuse >=  mca_btl_tcp_component.tcp_num_links) {
@@ -810,12 +810,15 @@ mca_btl_tcp_proc_t* mca_btl_tcp_proc_lookup(const opal_process_name_t *name)
 void mca_btl_tcp_proc_accept(mca_btl_tcp_proc_t* btl_proc, struct sockaddr* addr, int sd)
 {
     OPAL_THREAD_LOCK(&btl_proc->proc_lock);
+    int found_match = 0;
+    mca_btl_base_endpoint_t* match_btl_endpoint;
+
     for( size_t i = 0; i < btl_proc->proc_endpoint_count; i++ ) {
         mca_btl_base_endpoint_t* btl_endpoint = btl_proc->proc_endpoints[i];
         /* We are not here to make a decision about what is good socket
          * and what is not. We simply check that this socket fit the endpoint
          * end we prepare for the real decision function mca_btl_tcp_endpoint_accept. */
-        if( btl_endpoint->endpoint_addr->addr_family != addr->sa_family ) {
+        if( btl_endpoint->endpoint_addr->addr_family != addr->sa_family) {
             continue;
         }
         switch (addr->sa_family) {
@@ -833,6 +836,10 @@ void mca_btl_tcp_proc_accept(mca_btl_tcp_proc_t* btl_proc, struct sockaddr* addr
                                               tmp[1], 16),
                                     (int)i, (int)btl_proc->proc_endpoint_count);
                 continue;
+            } else if (btl_endpoint->endpoint_state != MCA_BTL_TCP_CLOSED) {
+                 found_match = 1;
+                 match_btl_endpoint = btl_endpoint;
+                 continue;
             }
             break;
 #if OPAL_ENABLE_IPV6
@@ -857,7 +864,17 @@ void mca_btl_tcp_proc_accept(mca_btl_tcp_proc_t* btl_proc, struct sockaddr* addr
             ;
         }
 
+        /* Set state to CONNECTING to ensure that subsequent conenctions do not attempt to re-use endpoint in the num_links > 1 case*/
+        btl_endpoint->endpoint_state = MCA_BTL_TCP_CONNECTING;
         (void)mca_btl_tcp_endpoint_accept(btl_endpoint, addr, sd);
+        OPAL_THREAD_UNLOCK(&btl_proc->proc_lock);
+        return;
+    }
+    /* In this case the connection was inbound to an address exported, but was not in a CLOSED state.
+     * mca_btl_tcp_endpoint_accept() has logic to deal with the race condition that has likely caused this
+     * scenario, so call it here.*/
+    if (found_match) {
+        (void)mca_btl_tcp_endpoint_accept(match_btl_endpoint, addr, sd);
         OPAL_THREAD_UNLOCK(&btl_proc->proc_lock);
         return;
     }

--- a/opal/mca/pmix/pmix3x/pmix/include/pmix_common.h.in
+++ b/opal/mca/pmix/pmix3x/pmix/include/pmix_common.h.in
@@ -99,10 +99,11 @@ typedef uint32_t pmix_rank_t;
  * data for the given key from every rank that posted
  * that key */
 #define PMIX_RANK_WILDCARD  UINT32_MAX-1
-
 /* other special rank values will be used to define
  * groups of ranks for use in collectives */
 #define PMIX_RANK_LOCAL_NODE    UINT32_MAX-2        // all ranks on local node
+/* define an invalid value */
+#define PMIX_RANK_INVALID   UINT32_MAX-3
 
 
 /* define a set of "standard" PMIx attributes that can
@@ -148,6 +149,8 @@ typedef uint32_t pmix_rank_t;
 #define PMIX_TOOL_DO_NOT_CONNECT            "pmix.tool.nocon"       // (bool) the tool wants to use internal PMIx support, but does
                                                                     //        not want to connect to a PMIx server
                                                                     //        from the specified processes to this tool
+#define PMIX_RECONNECT_SERVER               "pmix.cnct.recon"       // (bool) tool is requesting to change server connections
+#define PMIX_LAUNCHER                       "pmix.tool.launcher"    // (bool) tool is a launcher and needs rendezvous files created
 
 /* identification attributes */
 #define PMIX_USERID                         "pmix.euid"             // (uint32_t) effective user id
@@ -196,7 +199,7 @@ typedef uint32_t pmix_rank_t;
 
 /* information about relative ranks as assigned by the RM */
 #define PMIX_CLUSTER_ID                     "pmix.clid"             // (char*) a string name for the cluster this proc is executing on
-#define PMIX_PROCID                         "pmix.procid"           // (pmix_proc_t) process identifier
+#define PMIX_PROCID                         "pmix.procid"           // (pmix_proc_t*) process identifier
 #define PMIX_NSPACE                         "pmix.nspace"           // (char*) nspace of a job
 #define PMIX_JOBID                          "pmix.jobid"            // (char*) jobid assigned by scheduler
 #define PMIX_APPNUM                         "pmix.appnum"           // (uint32_t) app number within the job
@@ -223,7 +226,7 @@ typedef uint32_t pmix_rank_t;
 #define PMIX_LOCALITY                       "pmix.loc"              // (uint16_t) relative locality of two procs
 #define PMIX_PARENT_ID                      "pmix.parent"           // (pmix_proc_t*) identifier of the process that called PMIx_Spawn
                                                                     //                to launch this proc's application
-
+#define PMIX_EXIT_CODE                      "pmix.exit.code"        // (int) exit code returned when proc terminated
 
 /* size info */
 #define PMIX_UNIV_SIZE                      "pmix.univ.size"        // (uint32_t) #procs in this nspace
@@ -306,7 +309,7 @@ typedef uint32_t pmix_rank_t;
 #define PMIX_EVENT_HDLR_PREPEND             "pmix.evprepend"        // (bool) prepend this handler to the precedence list within its category
 #define PMIX_EVENT_HDLR_APPEND              "pmix.evappend"         // (bool) append this handler to the precedence list within its category
 #define PMIX_EVENT_CUSTOM_RANGE             "pmix.evrange"          // (pmix_data_array_t*) array of pmix_proc_t defining range of event notification
-#define PMIX_EVENT_AFFECTED_PROC            "pmix.evproc"           // (pmix_proc_t) single proc that was affected
+#define PMIX_EVENT_AFFECTED_PROC            "pmix.evproc"           // (pmix_proc_t*) single proc that was affected
 #define PMIX_EVENT_AFFECTED_PROCS           "pmix.evaffected"       // (pmix_data_array_t*) array of pmix_proc_t defining affected procs
 #define PMIX_EVENT_NON_DEFAULT              "pmix.evnondef"         // (bool) event is not to be delivered to default event handlers
 #define PMIX_EVENT_RETURN_OBJECT            "pmix.evobject"         // (void*) object to be returned whenever the registered cbfunc is invoked
@@ -324,7 +327,8 @@ typedef uint32_t pmix_rank_t;
 #define PMIX_EVENT_ACTION_TIMEOUT           "pmix.evtimeout"        // (int) time in sec before RM will execute error response
 #define PMIX_EVENT_NO_TERMINATION           "pmix.evnoterm"         // (bool) indicates that the handler has satisfactorily handled
                                                                     //        the event and believes termination of the application is not required
-#define PMIX_EVENT_WANT_TERMINATION         "pmix.evterm"           // (bool) indicates that the handler has determined that the application should be terminated
+#define PMIX_EVENT_WANT_TERMINATION         "pmix.evterm"           // (bool) indicates that the handler has determined that the
+                                                                    //        application should be terminated
 
 
 /* attributes used to describe "spawn" directives */
@@ -344,8 +348,8 @@ typedef uint32_t pmix_rank_t;
 #define PMIX_PRELOAD_BIN                    "pmix.preloadbin"       // (bool) preload binaries
 #define PMIX_PRELOAD_FILES                  "pmix.preloadfiles"     // (char*) comma-delimited list of files to pre-position
 #define PMIX_NON_PMI                        "pmix.nonpmi"           // (bool) spawned procs will not call PMIx_Init
-#define PMIX_STDIN_TGT                      "pmix.stdin"            // (pmix_proc_t) proc that is to receive stdin
-                                                                    //               (PMIX_RANK_WILDCARD = all in given nspace)
+#define PMIX_STDIN_TGT                      "pmix.stdin"            // (pmix_proc_t*) proc that is to receive stdin
+                                                                    //                (PMIX_RANK_WILDCARD = all in given nspace)
 #define PMIX_DEBUGGER_DAEMONS               "pmix.debugger"         // (bool) spawned app consists of debugger daemons
 #define PMIX_COSPAWN_APP                    "pmix.cospawn"          // (bool) designated app is to be spawned as a disconnected
                                                                     //        job - i.e., not part of the "comm_world" of the job
@@ -420,7 +424,9 @@ typedef uint32_t pmix_rank_t;
 #define PMIX_DEBUG_STOP_ON_EXEC             "pmix.dbg.exec"         // (bool) job is being spawned under debugger - instruct it to pause on start
 #define PMIX_DEBUG_STOP_IN_INIT             "pmix.dbg.init"         // (bool) instruct job to stop during PMIx init
 #define PMIX_DEBUG_WAIT_FOR_NOTIFY          "pmix.dbg.notify"       // (bool) block at desired point until receiving debugger release notification
-#define PMIX_DEBUG_JOB                      "pmix.dbg.job"          // (char*) nspace of the job to be debugged - the RM/PMIx server are
+#define PMIX_DEBUG_JOB                      "pmix.dbg.job"          // (char*) nspace of the job assigned to this debugger to be debugged. Note
+                                                                    //         that id's, pids, and other info on the procs is available
+                                                                    //         via a query for the nspace's local or global proctable
 #define PMIX_DEBUG_WAITING_FOR_NOTIFY       "pmix.dbg.waiting"      // (bool) job to be debugged is waiting for a release
 #define PMIX_DEBUG_JOB_DIRECTIVES           "pmix.dbg.jdirs"        // (pmix_data_array_t) array of job-level directives
 #define PMIX_DEBUG_APP_DIRECTIVES           "pmix.dbg.adirs"        // (pmix_data_array_t) array of app-level directives
@@ -683,6 +689,7 @@ typedef int pmix_status_t;
 #define PMIX_PROC_HAS_CONNECTED                 (PMIX_ERR_OP_BASE - 19)
 #define PMIX_CONNECT_REQUESTED                  (PMIX_ERR_OP_BASE - 20)
 #define PMIX_LAUNCH_DIRECTIVE                   (PMIX_ERR_OP_BASE - 21)
+#define PMIX_LAUNCHER_READY                     (PMIX_ERR_OP_BASE - 22)
 
 /* define a starting point for system error constants so
  * we avoid renumbering when making additions */
@@ -803,6 +810,7 @@ typedef uint8_t pmix_data_range_t;
 #define PMIX_RANGE_GLOBAL       5   // data available to all procs
 #define PMIX_RANGE_CUSTOM       6   // range is specified in a pmix_info_t
 #define PMIX_RANGE_PROC_LOCAL   7   // restrict range to the local proc
+#define PMIX_RANGE_INVALID   UINT8_MAX
 
 /* define a "persistence" policy for data published by clients */
 typedef uint8_t pmix_persistence_t;
@@ -811,6 +819,7 @@ typedef uint8_t pmix_persistence_t;
 #define PMIX_PERSIST_PROC           2   // retain until publishing process terminates
 #define PMIX_PERSIST_APP            3   // retain until application terminates
 #define PMIX_PERSIST_SESSION        4   // retain until session/allocation terminates
+#define PMIX_PERSIST_INVALID   UINT8_MAX
 
 /* define a set of bit-mask flags for specifying behavior of
  * command directives via pmix_info_t arrays */
@@ -1203,11 +1212,14 @@ typedef struct pmix_value {
         if (PMIX_STRING == (m)->type) {                                             \
             if (NULL != (m)->data.string) {                                         \
                 free((m)->data.string);                                             \
+                (m)->data.string = NULL;                                            \
             }                                                                       \
         } else if ((PMIX_BYTE_OBJECT == (m)->type) ||                               \
                    (PMIX_COMPRESSED_STRING == (m)->type)) {                         \
             if (NULL != (m)->data.bo.bytes) {                                       \
                 free((m)->data.bo.bytes);                                           \
+                (m)->data.bo.bytes = NULL;                                          \
+                (m)->data.bo.size = 0;                                              \
             }                                                                       \
         } else if (PMIX_DATA_ARRAY == (m)->type) {                                  \
             if (NULL != (m)->data.darray && NULL != (m)->data.darray->array) {      \
@@ -1251,9 +1263,12 @@ typedef struct pmix_value {
                     }                                                               \
                 }                                                                   \
                 free((m)->data.darray->array);                                      \
+                (m)->data.darray->array = NULL;                                     \
+                (m)->data.darray->size = 0;                                         \
             }                                                                       \
             if (NULL != (m)->data.darray) {                                         \
                 free((m)->data.darray);                                             \
+                (m)->data.darray = NULL;                                            \
             }                                                                       \
         /**** DEPRECATED ****/                                                      \
         } else if (PMIX_INFO_ARRAY == (m)->type) {                                  \
@@ -1922,13 +1937,8 @@ PMIX_EXPORT void PMIx_Deregister_event_handler(size_t evhdlr_ref,
                                                pmix_op_cbfunc_t cbfunc,
                                                void *cbdata);
 
-/* Report an event to a process for notification via any
- * registered evhdlr. The evhdlr registration can be
- * called by both the server and the client application. On the
- * server side, the evhdlr is used to report events detected
- * by PMIx to the host server for handling. On the client side,
- * the evhdlr is used to notify the process of events
- * reported by the server - e.g., the failure of another process.
+/* Report an event for notification via any
+ * registered evhdlr.
  *
  * This function allows the host server to direct the server
  * convenience library to notify all registered local procs of
@@ -1936,22 +1946,37 @@ PMIX_EXPORT void PMIx_Deregister_event_handler(size_t evhdlr_ref,
  * The status indicates the event being reported.
  *
  * The client application can also call this function to notify the
- * resource manager of an event it encountered. It can request the host
- * server to notify the indicated processes about the event.
+ * resource manager and/or other processes of an event it encountered.
+ * It can also be used to asynchronously notify other parts of its
+ * own internal process - e.g., for one library to notify another
+ * when initialized inside the process.
  *
- * The array of procs identifies the processes that will be impacted
- * by the event. This could consist of a single process, or a number
- * of processes.
+ * status - status code indicating the event being reported
  *
- * The info array contains any further info the RM can and/or chooses
- * to provide.
+ * source - the process that generated the event
  *
- * The callback function will be called upon completion of the
- * notify_event function's actions. Note that any messages will
- * have been queued, but may not have been transmitted by this
- * time. Note that the caller is required to maintain the input
- * data until the callback function has been executed!
-*/
+ * range - the range in which the event is to be reported. For example,
+ *         a value of PMIX_RANGE_LOCAL would instruct the system
+ *         to only notify procs on the same local node as the
+ *         event generator.
+ *
+ * info - an array of pmix_info_t structures provided by the event
+ *        generator to pass any additional information about the
+ *        event. This can include an array of pmix_proc_t structs
+ *        describing the processes impacted by the event, the nature
+ *        of the event and its severity, etc. The precise contents
+ *        of the array will depend on the event generator.
+ *
+ * ninfo - number of elements in the info array
+ *
+ * cbfunc - callback function to be called upon completion of the
+ *          notify_event function's actions. Note that any messages
+ *          will have been queued, but may not have been transmitted
+ *          by this time. Note that the caller is required to maintain
+ *          the input data until the callback function has been executed!
+ *
+ * cbdata - the caller's provided void* object
+ */
 PMIX_EXPORT pmix_status_t PMIx_Notify_event(pmix_status_t status,
                                             const pmix_proc_t *source,
                                             pmix_data_range_t range,

--- a/opal/mca/pmix/pmix3x/pmix/include/pmix_tool.h
+++ b/opal/mca/pmix/pmix3x/pmix/include/pmix_tool.h
@@ -98,6 +98,36 @@ PMIX_EXPORT pmix_status_t PMIx_tool_init(pmix_proc_t *proc,
  * operation. */
 PMIX_EXPORT pmix_status_t PMIx_tool_finalize(void);
 
+/* Switch server connection. Closes the connection, if existing, to a server
+ * and establishes a connection to the specified server. The target server can
+ * be given as:
+ *
+ * - PMIX_CONNECT_TO_SYSTEM: connect solely to the system server
+ *
+ * - PMIX_CONNECT_SYSTEM_FIRST: a request to use the system server first,
+ *   if existing, and then look for the server specified in a different
+ *   attribute
+ *
+ * - PMIX_SERVER_URI: connect to the server at the given URI
+ *
+ * - PMIX_SERVER_NSPACE: connect to the server of a given nspace
+ *
+ * - PMIX_SERVER_PIDINFO: connect to a server embedded in the process with
+ *   the given pid
+ *
+ * Passing a _NULL_ value for the info array pointer is not allowed and will
+ * result in return of an error.
+ *
+ * NOTE: PMIx does not currently support on-the-fly changes to the tool's
+ * identifier. Thus, the new server must be under the same nspace manager
+ * (e.g., host RM) as the prior server so that the original nspace remains
+ * a unique assignment. The proc parameter is included here for obsolence
+ * protection in case this constraint is someday removed. Meantime, the
+ * proc parameter will be filled with the tool's existing nspace/rank, and
+ * the caller is welcome to pass _NULL_ in that location
+ */
+PMIX_EXPORT pmix_status_t PMIx_tool_connect_to_server(pmix_proc_t *proc,
+                                                      pmix_info_t info[], size_t ninfo);
 
 #if defined(c_plusplus) || defined(__cplusplus)
 }

--- a/opal/mca/pmix/pmix3x/pmix/src/client/pmix_client_get.c
+++ b/opal/mca/pmix/pmix3x/pmix/src/client/pmix_client_get.c
@@ -111,6 +111,7 @@ PMIX_EXPORT pmix_status_t PMIx_Get(const pmix_proc_t *proc, const char key[],
     rc = cb->status;
     if (NULL != val) {
         *val = cb->value;
+        cb->value = NULL;
     }
     PMIX_RELEASE(cb);
 

--- a/opal/mca/pmix/pmix3x/pmix/src/common/pmix_control.c
+++ b/opal/mca/pmix/pmix3x/pmix/src/common/pmix_control.c
@@ -127,16 +127,11 @@ PMIX_EXPORT pmix_status_t PMIx_Job_control_nb(const pmix_proc_t targets[], size_
         return PMIX_ERR_INIT;
     }
 
-    /* if we aren't connected, don't attempt to send */
-    if (!PMIX_PROC_IS_SERVER(pmix_globals.mypeer) && !pmix_globals.connected) {
-        PMIX_RELEASE_THREAD(&pmix_global_lock);
-        return PMIX_ERR_UNREACH;
-    }
-    PMIX_RELEASE_THREAD(&pmix_global_lock);
-
     /* if we are the server, then we just issue the request and
      * return the response */
-    if (PMIX_PROC_IS_SERVER(pmix_globals.mypeer)) {
+    if (PMIX_PROC_IS_SERVER(pmix_globals.mypeer) &&
+        !PMIX_PROC_IS_LAUNCHER(pmix_globals.mypeer)) {
+        PMIX_RELEASE_THREAD(&pmix_global_lock);
         if (NULL == pmix_host_server.job_control) {
             /* nothing we can do */
             return PMIX_ERR_NOT_SUPPORTED;
@@ -149,6 +144,13 @@ PMIX_EXPORT pmix_status_t PMIx_Job_control_nb(const pmix_proc_t targets[], size_
                                           cbfunc, cbdata);
         return rc;
     }
+
+    /* we need to send, so check for connection */
+    if (!pmix_globals.connected) {
+        PMIX_RELEASE_THREAD(&pmix_global_lock);
+        return PMIX_ERR_UNREACH;
+    }
+    PMIX_RELEASE_THREAD(&pmix_global_lock);
 
     /* if we are a client, then relay this request to the server */
     msg = PMIX_NEW(pmix_buffer_t);
@@ -237,16 +239,11 @@ PMIX_EXPORT pmix_status_t PMIx_Process_monitor_nb(const pmix_info_t *monitor, pm
         return PMIX_ERR_INIT;
     }
 
-    /* if we aren't connected, don't attempt to send */
-    if (!PMIX_PROC_IS_SERVER(pmix_globals.mypeer) && !pmix_globals.connected) {
-        PMIX_RELEASE_THREAD(&pmix_global_lock);
-        return PMIX_ERR_UNREACH;
-    }
-    PMIX_RELEASE_THREAD(&pmix_global_lock);
-
     /* if we are the server, then we just issue the request and
      * return the response */
-    if (PMIX_PROC_IS_SERVER(pmix_globals.mypeer)) {
+    if (PMIX_PROC_IS_SERVER(pmix_globals.mypeer) &&
+        !PMIX_PROC_IS_LAUNCHER(pmix_globals.mypeer)) {
+        PMIX_RELEASE_THREAD(&pmix_global_lock);
         if (NULL == pmix_host_server.monitor) {
             /* nothing we can do */
             return PMIX_ERR_NOT_SUPPORTED;
@@ -257,6 +254,13 @@ PMIX_EXPORT pmix_status_t PMIx_Process_monitor_nb(const pmix_info_t *monitor, pm
                                       directives, ndirs, cbfunc, cbdata);
         return rc;
     }
+
+    /* we need to send, so check for connection */
+    if (!pmix_globals.connected) {
+        PMIX_RELEASE_THREAD(&pmix_global_lock);
+        return PMIX_ERR_UNREACH;
+    }
+    PMIX_RELEASE_THREAD(&pmix_global_lock);
 
     /* if we are a client, then relay this request to the server */
     msg = PMIX_NEW(pmix_buffer_t);

--- a/opal/mca/pmix/pmix3x/pmix/src/common/pmix_iof.c
+++ b/opal/mca/pmix/pmix3x/pmix/src/common/pmix_iof.c
@@ -83,7 +83,8 @@ PMIX_EXPORT pmix_status_t PMIx_IOF_pull(const pmix_proc_t procs[], size_t nprocs
     }
 
     /* if we are a server, we cannot do this */
-    if (PMIX_PROC_IS_SERVER(pmix_globals.mypeer)) {
+    if (PMIX_PROC_IS_SERVER(pmix_globals.mypeer) &&
+        !PMIX_PROC_IS_LAUNCHER(pmix_globals.mypeer)) {
         PMIX_RELEASE_THREAD(&pmix_global_lock);
         return PMIX_ERR_NOT_SUPPORTED;
     }
@@ -236,7 +237,8 @@ pmix_status_t PMIx_IOF_push(const pmix_proc_t targets[], size_t ntargets,
 
     /* if we are not a server, then we send the provided
      * data to our server for processing */
-    if (!PMIX_PROC_IS_SERVER(pmix_globals.mypeer)) {
+    if (!PMIX_PROC_IS_SERVER(pmix_globals.mypeer) ||
+        PMIX_PROC_IS_LAUNCHER(pmix_globals.mypeer)) {
         msg = PMIX_NEW(pmix_buffer_t);
         if (NULL == msg) {
             return PMIX_ERR_NOMEM;

--- a/opal/mca/pmix/pmix3x/pmix/src/common/pmix_log.c
+++ b/opal/mca/pmix/pmix3x/pmix/src/common/pmix_log.c
@@ -73,21 +73,16 @@ PMIX_EXPORT pmix_status_t PMIx_Log_nb(const pmix_info_t data[], size_t ndata,
         return PMIX_ERR_INIT;
     }
 
-    /* if we aren't connected, don't attempt to send */
-    if (!PMIX_PROC_IS_SERVER(pmix_globals.mypeer) && !pmix_globals.connected) {
-        PMIX_RELEASE_THREAD(&pmix_global_lock);
-        return PMIX_ERR_UNREACH;
-    }
-    PMIX_RELEASE_THREAD(&pmix_global_lock);
-
     if (0 == ndata || NULL == data) {
         return PMIX_ERR_BAD_PARAM;
     }
 
     /* if we are the server, then we just log and
      * return the response */
-    if (PMIX_PROC_IS_SERVER(pmix_globals.mypeer)) {
-            if (NULL == pmix_host_server.log) {
+    if (PMIX_PROC_IS_SERVER(pmix_globals.mypeer) &&
+        !PMIX_PROC_IS_LAUNCHER(pmix_globals.mypeer)) {
+        PMIX_RELEASE_THREAD(&pmix_global_lock);
+           if (NULL == pmix_host_server.log) {
                 /* nothing we can do */
                 return PMIX_ERR_NOT_SUPPORTED;
             }
@@ -96,64 +91,71 @@ PMIX_EXPORT pmix_status_t PMIx_Log_nb(const pmix_info_t data[], size_t ndata,
             pmix_host_server.log(&pmix_globals.myid,
                                  data, ndata, directives, ndirs,
                                  cbfunc, cbdata);
-            rc = PMIX_SUCCESS;
-    } else {
-        /* if we are a client, then relay this request to the server */
-        cd = PMIX_NEW(pmix_shift_caddy_t);
-        cd->cbfunc.opcbfn = cbfunc;
-        cd->cbdata = cbdata;
-        msg = PMIX_NEW(pmix_buffer_t);
-        PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver,
-                         msg, &cmd, 1, PMIX_COMMAND);
-        if (PMIX_SUCCESS != rc) {
-            PMIX_ERROR_LOG(rc);
-            PMIX_RELEASE(msg);
-            PMIX_RELEASE(cd);
-            return rc;
-        }
-        PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver,
-                         msg, &ndata, 1, PMIX_SIZE);
-        if (PMIX_SUCCESS != rc) {
-            PMIX_ERROR_LOG(rc);
-            PMIX_RELEASE(msg);
-            PMIX_RELEASE(cd);
-            return rc;
-        }
-        PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver,
-                         msg, data, ndata, PMIX_INFO);
-        if (PMIX_SUCCESS != rc) {
-            PMIX_ERROR_LOG(rc);
-            PMIX_RELEASE(msg);
-            PMIX_RELEASE(cd);
-            return rc;
-        }
-        PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver,
-                         msg, &ndirs, 1, PMIX_SIZE);
-        if (PMIX_SUCCESS != rc) {
-            PMIX_ERROR_LOG(rc);
-            PMIX_RELEASE(msg);
-            PMIX_RELEASE(cd);
-            return rc;
-        }
-        if (0 < ndirs) {
-            PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver,
-                             msg, directives, ndirs, PMIX_INFO);
-            if (PMIX_SUCCESS != rc) {
-                PMIX_ERROR_LOG(rc);
-                PMIX_RELEASE(msg);
-                PMIX_RELEASE(cd);
-                return rc;
-            }
-        }
+            return PMIX_SUCCESS;
+    }
 
-        pmix_output_verbose(2, pmix_globals.debug_output,
-                            "pmix:log sending to server");
-        PMIX_PTL_SEND_RECV(rc, pmix_client_globals.myserver,
-                           msg, log_cbfunc, (void*)cd);
+    /* if we aren't connected, don't attempt to send */
+    if (!pmix_globals.connected) {
+        PMIX_RELEASE_THREAD(&pmix_global_lock);
+        return PMIX_ERR_UNREACH;
+    }
+    PMIX_RELEASE_THREAD(&pmix_global_lock);
+
+    /* if we are a client, then relay this request to the server */
+    cd = PMIX_NEW(pmix_shift_caddy_t);
+    cd->cbfunc.opcbfn = cbfunc;
+    cd->cbdata = cbdata;
+    msg = PMIX_NEW(pmix_buffer_t);
+    PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver,
+                     msg, &cmd, 1, PMIX_COMMAND);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        PMIX_RELEASE(msg);
+        PMIX_RELEASE(cd);
+        return rc;
+    }
+    PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver,
+                     msg, &ndata, 1, PMIX_SIZE);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        PMIX_RELEASE(msg);
+        PMIX_RELEASE(cd);
+        return rc;
+    }
+    PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver,
+                     msg, data, ndata, PMIX_INFO);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        PMIX_RELEASE(msg);
+        PMIX_RELEASE(cd);
+        return rc;
+    }
+    PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver,
+                     msg, &ndirs, 1, PMIX_SIZE);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        PMIX_RELEASE(msg);
+        PMIX_RELEASE(cd);
+        return rc;
+    }
+    if (0 < ndirs) {
+        PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver,
+                         msg, directives, ndirs, PMIX_INFO);
         if (PMIX_SUCCESS != rc) {
             PMIX_ERROR_LOG(rc);
+            PMIX_RELEASE(msg);
             PMIX_RELEASE(cd);
+            return rc;
         }
+    }
+
+    pmix_output_verbose(2, pmix_globals.debug_output,
+                        "pmix:log sending to server");
+    PMIX_PTL_SEND_RECV(rc, pmix_client_globals.myserver,
+                       msg, log_cbfunc, (void*)cd);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        PMIX_RELEASE(cd);
     }
     return rc;
 }

--- a/opal/mca/pmix/pmix3x/pmix/src/common/pmix_query.c
+++ b/opal/mca/pmix/pmix3x/pmix/src/common/pmix_query.c
@@ -118,20 +118,16 @@ PMIX_EXPORT pmix_status_t PMIx_Query_info_nb(pmix_query_t queries[], size_t nque
         return PMIX_ERR_INIT;
     }
 
-    /* if we aren't connected, don't attempt to send */
-    if (!PMIX_PROC_IS_SERVER(pmix_globals.mypeer) && !pmix_globals.connected) {
-        PMIX_RELEASE_THREAD(&pmix_global_lock);
-        return PMIX_ERR_UNREACH;
-    }
-    PMIX_RELEASE_THREAD(&pmix_global_lock);
-
     if (0 == nqueries || NULL == queries) {
+        PMIX_RELEASE_THREAD(&pmix_global_lock);
         return PMIX_ERR_BAD_PARAM;
     }
 
     /* if we are the server, then we just issue the query and
      * return the response */
-    if (PMIX_PROC_IS_SERVER(pmix_globals.mypeer)) {
+    if (PMIX_PROC_IS_SERVER(pmix_globals.mypeer) &&
+        !PMIX_PROC_IS_LAUNCHER(pmix_globals.mypeer)) {
+        PMIX_RELEASE_THREAD(&pmix_global_lock);
         if (NULL == pmix_host_server.query) {
             /* nothing we can do */
             return PMIX_ERR_NOT_SUPPORTED;
@@ -141,44 +137,51 @@ PMIX_EXPORT pmix_status_t PMIx_Query_info_nb(pmix_query_t queries[], size_t nque
         pmix_host_server.query(&pmix_globals.myid,
                                queries, nqueries,
                                cbfunc, cbdata);
-        rc = PMIX_SUCCESS;
-    } else {
-        /* if we are a client, then relay this request to the server */
-        cd = PMIX_NEW(pmix_query_caddy_t);
-        cd->cbfunc = cbfunc;
-        cd->cbdata = cbdata;
-        msg = PMIX_NEW(pmix_buffer_t);
-        PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver,
-                         msg, &cmd, 1, PMIX_COMMAND);
-        if (PMIX_SUCCESS != rc) {
-            PMIX_ERROR_LOG(rc);
-            PMIX_RELEASE(msg);
-            PMIX_RELEASE(cd);
-            return rc;
-        }
-        PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver,
-                         msg, &nqueries, 1, PMIX_SIZE);
-        if (PMIX_SUCCESS != rc) {
-            PMIX_ERROR_LOG(rc);
-            PMIX_RELEASE(msg);
-            PMIX_RELEASE(cd);
-            return rc;
-        }
-        PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver,
-                         msg, queries, nqueries, PMIX_QUERY);
-        if (PMIX_SUCCESS != rc) {
-            PMIX_ERROR_LOG(rc);
-            PMIX_RELEASE(msg);
-            PMIX_RELEASE(cd);
-            return rc;
-        }
-        pmix_output_verbose(2, pmix_globals.debug_output,
-                            "pmix:query sending to server");
-        PMIX_PTL_SEND_RECV(rc, pmix_client_globals.myserver,
-                           msg, query_cbfunc, (void*)cd);
-        if (PMIX_SUCCESS != rc) {
-            PMIX_RELEASE(cd);
-        }
+        return PMIX_SUCCESS;
+    }
+
+    /* if we aren't connected, don't attempt to send */
+    if (!pmix_globals.connected) {
+        PMIX_RELEASE_THREAD(&pmix_global_lock);
+        return PMIX_ERR_UNREACH;
+    }
+    PMIX_RELEASE_THREAD(&pmix_global_lock);
+
+    /* if we are a client, then relay this request to the server */
+    cd = PMIX_NEW(pmix_query_caddy_t);
+    cd->cbfunc = cbfunc;
+    cd->cbdata = cbdata;
+    msg = PMIX_NEW(pmix_buffer_t);
+    PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver,
+                     msg, &cmd, 1, PMIX_COMMAND);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        PMIX_RELEASE(msg);
+        PMIX_RELEASE(cd);
+        return rc;
+    }
+    PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver,
+                     msg, &nqueries, 1, PMIX_SIZE);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        PMIX_RELEASE(msg);
+        PMIX_RELEASE(cd);
+        return rc;
+    }
+    PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver,
+                     msg, queries, nqueries, PMIX_QUERY);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        PMIX_RELEASE(msg);
+        PMIX_RELEASE(cd);
+        return rc;
+    }
+    pmix_output_verbose(2, pmix_globals.debug_output,
+                        "pmix:query sending to server");
+    PMIX_PTL_SEND_RECV(rc, pmix_client_globals.myserver,
+                       msg, query_cbfunc, (void*)cd);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_RELEASE(cd);
     }
     return rc;
 }
@@ -195,13 +198,18 @@ PMIX_EXPORT pmix_status_t PMIx_Allocation_request_nb(pmix_alloc_directive_t dire
     pmix_output_verbose(2, pmix_globals.debug_output,
                         "pmix: allocate called");
 
+    PMIX_ACQUIRE_THREAD(&pmix_global_lock);
+
     if (pmix_globals.init_cntr <= 0) {
+        PMIX_RELEASE_THREAD(&pmix_global_lock);
         return PMIX_ERR_INIT;
     }
 
     /* if we are the server, then we just issue the request and
      * return the response */
-    if (PMIX_PROC_IS_SERVER(pmix_globals.mypeer)) {
+    if (PMIX_PROC_IS_SERVER(pmix_globals.mypeer) &&
+        !PMIX_PROC_IS_LAUNCHER(pmix_globals.mypeer)) {
+        PMIX_RELEASE_THREAD(&pmix_global_lock);
         if (NULL == pmix_host_server.allocate) {
             /* nothing we can do */
             return PMIX_ERR_NOT_SUPPORTED;
@@ -219,8 +227,10 @@ PMIX_EXPORT pmix_status_t PMIx_Allocation_request_nb(pmix_alloc_directive_t dire
 
     /* if we aren't connected, don't attempt to send */
     if (!pmix_globals.connected) {
+        PMIX_RELEASE_THREAD(&pmix_global_lock);
         return PMIX_ERR_UNREACH;
     }
+    PMIX_RELEASE_THREAD(&pmix_global_lock);
 
     msg = PMIX_NEW(pmix_buffer_t);
     /* pack the cmd */

--- a/opal/mca/pmix/pmix3x/pmix/src/common/pmix_security.c
+++ b/opal/mca/pmix/pmix3x/pmix/src/common/pmix_security.c
@@ -131,7 +131,8 @@ PMIX_EXPORT pmix_status_t PMIx_Get_credential(const pmix_info_t info[], size_t n
     }
 
     /* if we are the server */
-    if (PMIX_PROC_IS_SERVER(pmix_globals.mypeer)) {
+    if (PMIX_PROC_IS_SERVER(pmix_globals.mypeer) &&
+        !PMIX_PROC_IS_LAUNCHER(pmix_globals.mypeer)) {
         PMIX_RELEASE_THREAD(&pmix_global_lock);
         /* if the host doesn't support this operation,
          * see if we can generate it ourselves */
@@ -316,7 +317,8 @@ PMIX_EXPORT pmix_status_t PMIx_Validate_credential(const pmix_byte_object_t *cre
     }
 
     /* if we are the server */
-    if (PMIX_PROC_IS_SERVER(pmix_globals.mypeer)) {
+    if (PMIX_PROC_IS_SERVER(pmix_globals.mypeer) &&
+        !PMIX_PROC_IS_LAUNCHER(pmix_globals.mypeer)) {
         PMIX_RELEASE_THREAD(&pmix_global_lock);
         /* if the host doesn't support this operation,
          * see if we can validate it ourselves */

--- a/opal/mca/pmix/pmix3x/pmix/src/common/pmix_strings.c
+++ b/opal/mca/pmix/pmix3x/pmix/src/common/pmix_strings.c
@@ -121,6 +121,8 @@ PMIX_EXPORT const char* PMIx_Persistence_string(pmix_persistence_t persist)
             return "RETAIN UNTIL APPLICATION OF PUBLISHING PROCESS TERMINATES";
         case PMIX_PERSIST_SESSION:
             return "RETAIN UNTIL ALLOCATION OF PUBLISHING PROCESS TERMINATES";
+        case PMIX_PERSIST_INVALID:
+            return "INVALID";
         default:
             return "UNKNOWN PERSISTENCE";
     }
@@ -145,6 +147,8 @@ PMIX_EXPORT const char* PMIx_Data_range_string(pmix_data_range_t range)
             return "AVAIL AS SPECIFIED IN DIRECTIVES";
         case PMIX_RANGE_PROC_LOCAL:
             return "AVAIL ON LOCAL PROC ONLY";
+        case PMIX_RANGE_INVALID:
+            return "INVALID";
         default:
             return "UNKNOWN";
     }

--- a/opal/mca/pmix/pmix3x/pmix/src/event/pmix_event.h
+++ b/opal/mca/pmix/pmix3x/pmix/src/event/pmix_event.h
@@ -53,7 +53,22 @@ typedef struct {
     size_t index;
     uint8_t precedence;
     char *locator;
+    pmix_proc_t source;  // who generated this event
+    /* When registering for events, callers can specify
+     * the range of sources from which they are willing
+     * to receive notifications - e.g., for callers to
+     * define different handlers for events coming from
+     * the RM vs those coming from their peers. We use
+     * the rng field to track these values upon registration.
+     */
     pmix_range_trkr_t rng;
+    /* For registration, we use the affected field to track
+     * the range of procs that, if affected by the event,
+     * should cause the handler to be called (subject, of
+     * course, to any rng constraints).
+     */
+    pmix_proc_t *affected;
+    size_t naffected;
     pmix_notification_fn_t evhdlr;
     void *cbobject;
     pmix_status_t *codes;
@@ -102,8 +117,11 @@ typedef struct pmix_event_chain_t {
     bool endchain;
     pmix_proc_t source;
     pmix_data_range_t range;
+    pmix_proc_t *affected;
+    size_t naffected;
     pmix_info_t *info;
     size_t ninfo;
+    size_t nallocated;
     pmix_info_t *results;
     size_t nresults;
     pmix_event_hdlr_t *evhdlr;

--- a/opal/mca/pmix/pmix3x/pmix/src/event/pmix_event_notification.c
+++ b/opal/mca/pmix/pmix3x/pmix/src/event/pmix_event_notification.c
@@ -33,7 +33,11 @@ static pmix_status_t notify_server_of_event(pmix_status_t status,
                                             pmix_info_t info[], size_t ninfo,
                                             pmix_op_cbfunc_t cbfunc, void *cbdata);
 
-static bool check_range(pmix_range_trkr_t *range, const pmix_proc_t *proc);
+static bool check_range(pmix_range_trkr_t *range,
+                        const pmix_proc_t *proc);
+
+static bool check_affected(pmix_proc_t *interested, size_t ninterested,
+                           pmix_proc_t *affected, size_t naffected);
 
 /* if we are a client, we call this function to notify the server of
  * an event. If we are a server, our host RM will call this function
@@ -53,15 +57,10 @@ PMIX_EXPORT pmix_status_t PMIx_Notify_event(pmix_status_t status,
         return PMIX_ERR_INIT;
     }
 
-    /* if we aren't connected, don't attempt to send */
-    if (!PMIX_PROC_IS_SERVER(pmix_globals.mypeer) && !pmix_globals.connected) {
+
+    if (PMIX_PROC_IS_SERVER(pmix_globals.mypeer) &&
+        !PMIX_PROC_IS_LAUNCHER(pmix_globals.mypeer)) {
         PMIX_RELEASE_THREAD(&pmix_global_lock);
-        return PMIX_ERR_UNREACH;
-    }
-    PMIX_RELEASE_THREAD(&pmix_global_lock);
-
-
-    if (PMIX_PROC_IS_SERVER(pmix_globals.mypeer)) {
         rc = pmix_server_notify_client_of_event(status, source, range,
                                                 info, ninfo,
                                                 cbfunc, cbdata);
@@ -69,15 +68,23 @@ PMIX_EXPORT pmix_status_t PMIx_Notify_event(pmix_status_t status,
                             "pmix_server_notify_event source = %s:%d event_status = %d, rc= %d",
                             (NULL == source) ? "UNKNOWN" : source->nspace,
                             (NULL == source) ? PMIX_RANK_WILDCARD : source->rank, status, rc);
-    } else {
-        rc = notify_server_of_event(status, source, range,
-                                    info, ninfo,
-                                    cbfunc, cbdata);
-        pmix_output_verbose(2, pmix_client_globals.event_output,
-                            "pmix_client_notify_event source = %s:%d event_status =%d, rc=%d",
-                            (NULL == source) ? pmix_globals.myid.nspace : source->nspace,
-                            (NULL == source) ? pmix_globals.myid.rank : source->rank, status, rc);
+        return rc;
     }
+
+    /* if we aren't connected, don't attempt to send */
+    if (!pmix_globals.connected) {
+        PMIX_RELEASE_THREAD(&pmix_global_lock);
+        return PMIX_ERR_UNREACH;
+    }
+    PMIX_RELEASE_THREAD(&pmix_global_lock);
+
+    rc = notify_server_of_event(status, source, range,
+                                info, ninfo,
+                                cbfunc, cbdata);
+    pmix_output_verbose(2, pmix_client_globals.event_output,
+                        "pmix_client_notify_event source = %s:%d event_status =%d, rc=%d",
+                        (NULL == source) ? pmix_globals.myid.nspace : source->nspace,
+                        (NULL == source) ? pmix_globals.myid.rank : source->rank, status, rc);
     return rc;
 }
 
@@ -167,22 +174,17 @@ static pmix_status_t notify_server_of_event(pmix_status_t status,
     chain->status = status;
     (void)strncpy(chain->source.nspace, pmix_globals.myid.nspace, PMIX_MAX_NSLEN);
     chain->source.rank = pmix_globals.myid.rank;
-    /* we always leave space for a callback object and
-     * the evhandler name. */
-    chain->ninfo = ninfo + 2;
-    PMIX_INFO_CREATE(chain->info, chain->ninfo);
+    /* we always leave space for event hdlr name and a callback object */
+    chain->nallocated = ninfo + 2;
+    PMIX_INFO_CREATE(chain->info, chain->nallocated);
 
     if (0 < ninfo) {
+        chain->ninfo = ninfo;
         /* need to copy the info */
         for (n=0; n < ninfo; n++) {
             PMIX_INFO_XFER(&chain->info[n], &info[n]);
         }
     }
-    /* add the evhandler name tag - we
-     * will fill it in as each handler is called */
-    PMIX_INFO_LOAD(&chain->info[chain->ninfo-2], PMIX_EVENT_HDLR_NAME, NULL, PMIX_STRING);
-    /* now add the callback object tag */
-    PMIX_INFO_LOAD(&chain->info[chain->ninfo-1], PMIX_EVENT_RETURN_OBJECT, NULL, PMIX_POINTER);
 
     /* we need to cache this event so we can pass it into
      * ourselves should someone later register for it */
@@ -204,6 +206,7 @@ static pmix_status_t notify_server_of_event(pmix_status_t status,
             PMIX_INFO_XFER(&cd->info[n], &chain->info[n]);
             if (0 == strncmp(cd->info[n].key, PMIX_EVENT_NON_DEFAULT, PMIX_MAX_KEYLEN)) {
                 cd->nondefault = true;
+                chain->nondefault = true;
             } else if (0 == strncmp(cd->info[n].key, PMIX_EVENT_CUSTOM_RANGE, PMIX_MAX_KEYLEN)) {
                 /* provides an array of pmix_proc_t identifying the procs
                  * that are to receive this notification, or a single pmix_proc_t  */
@@ -222,6 +225,36 @@ static pmix_status_t notify_server_of_event(pmix_status_t status,
                     PMIX_ERROR_LOG(PMIX_ERR_BAD_PARAM);
                     return PMIX_ERR_BAD_PARAM;
                 }
+            } else if (0 == strncmp(cd->info[n].key, PMIX_EVENT_AFFECTED_PROC, PMIX_MAX_KEYLEN)) {
+                PMIX_PROC_CREATE(cd->affected, 1);
+                if (NULL == cd->affected) {
+                    goto cleanup;
+                }
+                cd->naffected = 1;
+                memcpy(cd->affected, cd->info[n].value.data.proc, sizeof(pmix_proc_t));
+                /* need to do the same for chain so it can be correctly processed */
+                PMIX_PROC_CREATE(chain->affected, 1);
+                if (NULL == chain->affected) {
+                    goto cleanup;
+                }
+                chain->naffected = 1;
+                memcpy(chain->affected, cd->info[n].value.data.proc, sizeof(pmix_proc_t));
+            } else if (0 == strncmp(cd->info[n].key, PMIX_EVENT_AFFECTED_PROCS, PMIX_MAX_KEYLEN)) {
+                cd->naffected = cd->info[n].value.data.darray->size;
+                PMIX_PROC_CREATE(cd->affected, cd->naffected);
+                if (NULL == cd->affected) {
+                    cd->naffected = 0;
+                    goto cleanup;
+                }
+                memcpy(cd->affected, cd->info[n].value.data.darray->array, cd->naffected * sizeof(pmix_proc_t));
+                /* need to do the same for chain so it can be correctly processed */
+                chain->naffected = cd->info[n].value.data.darray->size;
+                PMIX_PROC_CREATE(chain->affected, chain->naffected);
+                if (NULL == chain->affected) {
+                    chain->naffected = 0;
+                    goto cleanup;
+                }
+                memcpy(chain->affected, cd->info[n].value.data.darray->array, chain->naffected * sizeof(pmix_proc_t));
             }
         }
     }
@@ -332,6 +365,10 @@ static void progress_local_event_hdlr(pmix_status_t status,
     /* pass along the new ones */
     chain->results = newinfo;
     chain->nresults = cnt;
+    /* clear any loaded name and object */
+    chain->ninfo = chain->nallocated - 2;
+    PMIX_INFO_DESTRUCT(&chain->info[chain->nallocated-2]);
+    PMIX_INFO_DESTRUCT(&chain->info[chain->nallocated-1]);
 
     /* if the caller indicates that the chain is completed,
      * or we completed the "last" event */
@@ -348,28 +385,22 @@ static void progress_local_event_hdlr(pmix_status_t status,
         while (pmix_list_get_end(&pmix_globals.events.single_events) != (item = pmix_list_get_next(item))) {
             nxt = (pmix_event_hdlr_t*)item;
             if (nxt->codes[0] == chain->status &&
-                check_range(&nxt->rng, &chain->source)) {
+                check_range(&nxt->rng, &chain->source) &&
+                check_affected(nxt->affected, nxt->naffected,
+                               chain->affected, chain->naffected)) {
                 chain->evhdlr = nxt;
-                /* update the handler name in case they want to reference it */
-                for (n=0; n < chain->ninfo; n++) {
-                    if (0 == strncmp(chain->info[n].key, PMIX_EVENT_HDLR_NAME, PMIX_MAX_KEYLEN)) {
-                        if (NULL != chain->info[n].value.data.string) {
-                            free(chain->info[n].value.data.string);
-                        }
-                        if (NULL != chain->evhdlr->name) {
-                            chain->info[n].value.data.string = strdup(chain->evhdlr->name);
-                        }
-                        break;
-                    }
+                /* reset our count to the info provided by the caller */
+                chain->ninfo = chain->nallocated - 2;
+                /* if the handler has a name, then provide it */
+                if (NULL != chain->evhdlr->name) {
+                    PMIX_INFO_LOAD(&chain->info[chain->ninfo], PMIX_EVENT_HDLR_NAME, chain->evhdlr->name, PMIX_STRING);
+                    chain->ninfo++;
                 }
-                /* update the evhdlr cbobject */
-                for (n=0; n < chain->ninfo; n++) {
-                    if (0 == strncmp(chain->info[n].key, PMIX_EVENT_RETURN_OBJECT, PMIX_MAX_KEYLEN)) {
-                        if (NULL != chain->evhdlr->name) {
-                            chain->info[n].value.data.ptr = chain->evhdlr->cbobject;
-                        }
-                        break;
-                    }
+
+                /* if there is an evhdlr cbobject, provide it */
+                if (NULL != chain->evhdlr->cbobject) {
+                    PMIX_INFO_LOAD(&chain->info[chain->ninfo], PMIX_EVENT_RETURN_OBJECT, chain->evhdlr->cbobject, PMIX_POINTER);
+                    chain->ninfo++;
                 }
                 nxt->evhdlr(nxt->index,
                             chain->status, &chain->source,
@@ -394,7 +425,9 @@ static void progress_local_event_hdlr(pmix_status_t status,
         }
         while (pmix_list_get_end(&pmix_globals.events.multi_events) != (item = pmix_list_get_next(item))) {
             nxt = (pmix_event_hdlr_t*)item;
-            if (!check_range(&nxt->rng, &chain->source)) {
+            if (!check_range(&nxt->rng, &chain->source) &&
+                !check_affected(nxt->affected, nxt->naffected,
+                                chain->affected, chain->naffected)) {
                 continue;
             }
             for (n=0; n < nxt->ncodes; n++) {
@@ -402,26 +435,18 @@ static void progress_local_event_hdlr(pmix_status_t status,
                  * the source fits within it */
                 if (nxt->codes[n] == chain->status) {
                     chain->evhdlr = nxt;
-                    /* update the handler name in case they want to reference it */
-                    for (n=0; n < chain->ninfo; n++) {
-                        if (0 == strncmp(chain->info[n].key, PMIX_EVENT_HDLR_NAME, PMIX_MAX_KEYLEN)) {
-                            if (NULL != chain->info[n].value.data.string) {
-                                free(chain->info[n].value.data.string);
-                            }
-                            if (NULL != chain->evhdlr->name) {
-                                chain->info[n].value.data.string = strdup(chain->evhdlr->name);
-                            }
-                            break;
-                        }
+                    /* reset our count to the info provided by the caller */
+                    chain->ninfo = chain->nallocated - 2;
+                    /* if the handler has a name, then provide it */
+                    if (NULL != chain->evhdlr->name) {
+                        PMIX_INFO_LOAD(&chain->info[chain->ninfo], PMIX_EVENT_HDLR_NAME, chain->evhdlr->name, PMIX_STRING);
+                        chain->ninfo++;
                     }
-                    /* update the evhdlr cbobject */
-                    for (n=0; n < chain->ninfo; n++) {
-                        if (0 == strncmp(chain->info[n].key, PMIX_EVENT_RETURN_OBJECT, PMIX_MAX_KEYLEN)) {
-                            if (NULL != chain->evhdlr->name) {
-                                chain->info[n].value.data.ptr = chain->evhdlr->cbobject;
-                            }
-                            break;
-                        }
+
+                    /* if there is an evhdlr cbobject, provide it */
+                    if (NULL != chain->evhdlr->cbobject) {
+                        PMIX_INFO_LOAD(&chain->info[chain->ninfo], PMIX_EVENT_RETURN_OBJECT, chain->evhdlr->cbobject, PMIX_POINTER);
+                        chain->ninfo++;
                     }
                     nxt->evhdlr(nxt->index,
                                 chain->status, &chain->source,
@@ -446,28 +471,22 @@ static void progress_local_event_hdlr(pmix_status_t status,
             nxt = (pmix_event_hdlr_t*)item;
             /* if this event handler provided a range, check to see if
              * the source fits within it */
-            if (check_range(&nxt->rng, &chain->source)) {
+            if (check_range(&nxt->rng, &chain->source) &&
+                check_affected(nxt->affected, nxt->naffected,
+                               chain->affected, chain->naffected)) {
                 chain->evhdlr = nxt;
-                /* update the handler name in case they want to reference it */
-                for (n=0; n < chain->ninfo; n++) {
-                    if (0 == strncmp(chain->info[n].key, PMIX_EVENT_HDLR_NAME, PMIX_MAX_KEYLEN)) {
-                        if (NULL != chain->info[n].value.data.string) {
-                            free(chain->info[n].value.data.string);
-                        }
-                        if (NULL != chain->evhdlr->name) {
-                            chain->info[n].value.data.string = strdup(chain->evhdlr->name);
-                        }
-                        break;
-                    }
+                /* reset our count to the info provided by the caller */
+                chain->ninfo = chain->nallocated - 2;
+                /* if the handler has a name, then provide it */
+                if (NULL != chain->evhdlr->name) {
+                    PMIX_INFO_LOAD(&chain->info[chain->ninfo], PMIX_EVENT_HDLR_NAME, chain->evhdlr->name, PMIX_STRING);
+                    chain->ninfo++;
                 }
-                /* update the evhdlr cbobject */
-                for (n=0; n < chain->ninfo; n++) {
-                    if (0 == strncmp(chain->info[n].key, PMIX_EVENT_RETURN_OBJECT, PMIX_MAX_KEYLEN)) {
-                        if (NULL != chain->evhdlr->name) {
-                            chain->info[n].value.data.ptr = chain->evhdlr->cbobject;
-                        }
-                        break;
-                    }
+
+                /* if there is an evhdlr cbobject, provide it */
+                if (NULL != chain->evhdlr->cbobject) {
+                    PMIX_INFO_LOAD(&chain->info[chain->ninfo], PMIX_EVENT_RETURN_OBJECT, chain->evhdlr->cbobject, PMIX_POINTER);
+                    chain->ninfo++;
                 }
                 nxt->evhdlr(nxt->index,
                             chain->status, &chain->source,
@@ -482,31 +501,25 @@ static void progress_local_event_hdlr(pmix_status_t status,
     /* if we registered a "last" handler, and it fits the given range
      * and code, then invoke it now */
     if (NULL != pmix_globals.events.last &&
-        check_range(&pmix_globals.events.last->rng, &chain->source)) {
+        check_range(&pmix_globals.events.last->rng, &chain->source) &&
+        check_affected(nxt->affected, nxt->naffected,
+                       chain->affected, chain->naffected)) {
         chain->endchain = true;  // ensure we don't do this again
         if (1 == pmix_globals.events.last->ncodes &&
             pmix_globals.events.last->codes[0] == chain->status) {
             chain->evhdlr = pmix_globals.events.last;
-            /* update the handler name in case they want to reference it */
-            for (n=0; n < chain->ninfo; n++) {
-                if (0 == strncmp(chain->info[n].key, PMIX_EVENT_HDLR_NAME, PMIX_MAX_KEYLEN)) {
-                    if (NULL != chain->info[n].value.data.string) {
-                        free(chain->info[n].value.data.string);
-                    }
-                    if (NULL != chain->evhdlr->name) {
-                        chain->info[n].value.data.string = strdup(chain->evhdlr->name);
-                    }
-                    break;
-                }
+            /* reset our count to the info provided by the caller */
+            chain->ninfo = chain->nallocated - 2;
+            /* if the handler has a name, then provide it */
+            if (NULL != chain->evhdlr->name) {
+                PMIX_INFO_LOAD(&chain->info[chain->ninfo], PMIX_EVENT_HDLR_NAME, chain->evhdlr->name, PMIX_STRING);
+                chain->ninfo++;
             }
-            /* update the evhdlr cbobject */
-            for (n=0; n < chain->ninfo; n++) {
-                if (0 == strncmp(chain->info[n].key, PMIX_EVENT_RETURN_OBJECT, PMIX_MAX_KEYLEN)) {
-                    if (NULL != chain->evhdlr->name) {
-                        chain->info[n].value.data.ptr = chain->evhdlr->cbobject;
-                    }
-                    break;
-                }
+
+            /* if there is an evhdlr cbobject, provide it */
+            if (NULL != chain->evhdlr->cbobject) {
+                PMIX_INFO_LOAD(&chain->info[chain->ninfo], PMIX_EVENT_RETURN_OBJECT, chain->evhdlr->cbobject, PMIX_POINTER);
+                chain->ninfo++;
             }
             chain->evhdlr->evhdlr(chain->evhdlr->index,
                                   chain->status, &chain->source,
@@ -519,26 +532,18 @@ static void progress_local_event_hdlr(pmix_status_t status,
             for (n=0; n < pmix_globals.events.last->ncodes; n++) {
                 if (pmix_globals.events.last->codes[n] == chain->status) {
                     chain->evhdlr = pmix_globals.events.last;
-                    /* update the handler name in case they want to reference it */
-                    for (n=0; n < chain->ninfo; n++) {
-                        if (0 == strncmp(chain->info[n].key, PMIX_EVENT_HDLR_NAME, PMIX_MAX_KEYLEN)) {
-                            if (NULL != chain->info[n].value.data.string) {
-                                free(chain->info[n].value.data.string);
-                            }
-                            if (NULL != chain->evhdlr->name) {
-                                chain->info[n].value.data.string = strdup(chain->evhdlr->name);
-                            }
-                            break;
-                        }
+                    /* reset our count to the info provided by the caller */
+                    chain->ninfo = chain->nallocated - 2;
+                    /* if the handler has a name, then provide it */
+                    if (NULL != chain->evhdlr->name) {
+                        PMIX_INFO_LOAD(&chain->info[chain->ninfo], PMIX_EVENT_HDLR_NAME, chain->evhdlr->name, PMIX_STRING);
+                        chain->ninfo++;
                     }
-                    /* update the evhdlr cbobject */
-                    for (n=0; n < chain->ninfo; n++) {
-                        if (0 == strncmp(chain->info[n].key, PMIX_EVENT_RETURN_OBJECT, PMIX_MAX_KEYLEN)) {
-                            if (NULL != chain->evhdlr->name) {
-                                chain->info[n].value.data.ptr = chain->evhdlr->cbobject;
-                            }
-                            break;
-                        }
+
+                    /* if there is an evhdlr cbobject, provide it */
+                    if (NULL != chain->evhdlr->cbobject) {
+                        PMIX_INFO_LOAD(&chain->info[chain->ninfo], PMIX_EVENT_RETURN_OBJECT, chain->evhdlr->cbobject, PMIX_POINTER);
+                        chain->ninfo++;
                     }
                     chain->evhdlr->evhdlr(chain->evhdlr->index,
                                           chain->status, &chain->source,
@@ -551,26 +556,18 @@ static void progress_local_event_hdlr(pmix_status_t status,
         } else {
             /* gets run for all codes */
             chain->evhdlr = pmix_globals.events.last;
-            /* update the handler name in case they want to reference it */
-            for (n=0; n < chain->ninfo; n++) {
-                if (0 == strncmp(chain->info[n].key, PMIX_EVENT_HDLR_NAME, PMIX_MAX_KEYLEN)) {
-                    if (NULL != chain->info[n].value.data.string) {
-                        free(chain->info[n].value.data.string);
-                    }
-                    if (NULL != chain->evhdlr->name) {
-                        chain->info[n].value.data.string = strdup(chain->evhdlr->name);
-                    }
-                    break;
-                }
+            /* reset our count to the info provided by the caller */
+            chain->ninfo = chain->nallocated - 2;
+            /* if the handler has a name, then provide it */
+            if (NULL != chain->evhdlr->name) {
+                PMIX_INFO_LOAD(&chain->info[chain->ninfo], PMIX_EVENT_HDLR_NAME, chain->evhdlr->name, PMIX_STRING);
+                chain->ninfo++;
             }
-            /* update the evhdlr cbobject */
-            for (n=0; n < chain->ninfo; n++) {
-                if (0 == strncmp(chain->info[n].key, PMIX_EVENT_RETURN_OBJECT, PMIX_MAX_KEYLEN)) {
-                    if (NULL != chain->evhdlr->name) {
-                        chain->info[n].value.data.ptr = chain->evhdlr->cbobject;
-                    }
-                    break;
-                }
+
+            /* if there is an evhdlr cbobject, provide it */
+            if (NULL != chain->evhdlr->cbobject) {
+                PMIX_INFO_LOAD(&chain->info[chain->ninfo], PMIX_EVENT_RETURN_OBJECT, chain->evhdlr->cbobject, PMIX_POINTER);
+                chain->ninfo++;
             }
             chain->evhdlr->evhdlr(chain->evhdlr->index,
                                   chain->status, &chain->source,
@@ -613,15 +610,15 @@ void pmix_invoke_local_event_hdlr(pmix_event_chain_t *chain)
     pmix_status_t rc = PMIX_SUCCESS;
     bool found;
 
-    pmix_output_verbose(2, pmix_globals.debug_output,
+    pmix_output_verbose(2, pmix_client_globals.event_output,
                         "%s:%d invoke_local_event_hdlr for status %s",
                         pmix_globals.myid.nspace, pmix_globals.myid.rank,
                         PMIx_Error_string(chain->status));
 
     /* sanity check */
     if (NULL == chain->info) {
-        /* should never happen as the return object must
-         * at least be there, even if it is NULL */
+        /* should never happen as space must always be
+         * reserved for handler name and callback object*/
         rc = PMIX_ERR_BAD_PARAM;
         goto complete;
     }
@@ -638,7 +635,9 @@ void pmix_invoke_local_event_hdlr(pmix_event_chain_t *chain)
     if (NULL != pmix_globals.events.first) {
         if (1 == pmix_globals.events.first->ncodes &&
             pmix_globals.events.first->codes[0] == chain->status &&
-            check_range(&pmix_globals.events.first->rng, &chain->source)) {
+            check_range(&pmix_globals.events.first->rng, &chain->source) &&
+            check_affected(pmix_globals.events.first->affected, pmix_globals.events.first->naffected,
+                           chain->affected, chain->naffected)) {
             /* invoke the handler */
             chain->evhdlr = pmix_globals.events.first;
             goto invk;
@@ -672,7 +671,9 @@ void pmix_invoke_local_event_hdlr(pmix_event_chain_t *chain)
     /* cycle thru the single-event registrations first */
     PMIX_LIST_FOREACH(evhdlr, &pmix_globals.events.single_events, pmix_event_hdlr_t) {
         if (evhdlr->codes[0] == chain->status) {
-            if (check_range(&evhdlr->rng, &chain->source)) {
+            if (check_range(&evhdlr->rng, &chain->source) &&
+                check_affected(evhdlr->affected, evhdlr->naffected,
+                               chain->affected, chain->naffected)) {
                 /* invoke the handler */
                 chain->evhdlr = evhdlr;
                 goto invk;
@@ -685,7 +686,9 @@ void pmix_invoke_local_event_hdlr(pmix_event_chain_t *chain)
     PMIX_LIST_FOREACH(evhdlr, &pmix_globals.events.multi_events, pmix_event_hdlr_t) {
         for (i=0; i < evhdlr->ncodes; i++) {
             if (evhdlr->codes[i] == chain->status) {
-                if (check_range(&evhdlr->rng, &chain->source)) {
+                if (check_range(&evhdlr->rng, &chain->source) &&
+                    check_affected(evhdlr->affected, evhdlr->naffected,
+                                   chain->affected, chain->naffected)) {
                     /* invoke the handler */
                     chain->evhdlr = evhdlr;
                     goto invk;
@@ -698,7 +701,9 @@ void pmix_invoke_local_event_hdlr(pmix_event_chain_t *chain)
     if (!chain->nondefault) {
         /* pass it to any default handlers */
         PMIX_LIST_FOREACH(evhdlr, &pmix_globals.events.default_events, pmix_event_hdlr_t) {
-            if (check_range(&evhdlr->rng, &chain->source)) {
+            if (check_range(&evhdlr->rng, &chain->source) &&
+                check_affected(evhdlr->affected, evhdlr->naffected,
+                               chain->affected, chain->naffected)) {
                 /* invoke the handler */
                 chain->evhdlr = evhdlr;
                 goto invk;
@@ -709,7 +714,9 @@ void pmix_invoke_local_event_hdlr(pmix_event_chain_t *chain)
     /* if we registered a "last" handler, and it fits the given range
      * and code, then invoke it now */
     if (NULL != pmix_globals.events.last &&
-        check_range(&pmix_globals.events.last->rng, &chain->source)) {
+        check_range(&pmix_globals.events.last->rng, &chain->source) &&
+        check_affected(pmix_globals.events.last->affected, pmix_globals.events.last->naffected,
+                       chain->affected, chain->naffected)) {
         chain->endchain = true;  // ensure we don't do this again
         if (1 == pmix_globals.events.last->ncodes &&
             pmix_globals.events.last->codes[0] == chain->status) {
@@ -741,29 +748,23 @@ void pmix_invoke_local_event_hdlr(pmix_event_chain_t *chain)
 
 
   invk:
-    /* update the handler name in case they want to reference it */
-    for (i=0; i < chain->ninfo; i++) {
-        if (0 == strncmp(chain->info[i].key, PMIX_EVENT_HDLR_NAME, PMIX_MAX_KEYLEN)) {
-            if (NULL != chain->info[i].value.data.string) {
-                free(chain->info[i].value.data.string);
-            }
-            if (NULL != chain->evhdlr->name) {
-                chain->info[i].value.data.string = strdup(chain->evhdlr->name);
-            }
-            break;
-        }
+    /* start with the chain holding only the given info */
+    chain->ninfo = chain->nallocated - 2;
+
+    /* if the handler has a name, then provide it */
+    if (NULL != chain->evhdlr->name) {
+        PMIX_INFO_LOAD(&chain->info[chain->ninfo], PMIX_EVENT_HDLR_NAME, chain->evhdlr->name, PMIX_STRING);
+        chain->ninfo++;
     }
-    /* update the evhdlr cbobject */
-    for (i=0; i < chain->ninfo; i++) {
-        if (0 == strncmp(chain->info[i].key, PMIX_EVENT_RETURN_OBJECT, PMIX_MAX_KEYLEN)) {
-            if (NULL != chain->evhdlr->name) {
-                chain->info[i].value.data.ptr = chain->evhdlr->cbobject;
-            }
-            break;
-        }
+
+    /* if there is an evhdlr cbobject, provide it */
+    if (NULL != chain->evhdlr->cbobject) {
+        PMIX_INFO_LOAD(&chain->info[chain->ninfo], PMIX_EVENT_RETURN_OBJECT, chain->evhdlr->cbobject, PMIX_POINTER);
+        chain->ninfo++;
     }
+
     /* invoke the handler */
-    pmix_output_verbose(2, pmix_globals.debug_output,
+    pmix_output_verbose(2, pmix_client_globals.event_output,
                         "[%s:%d] INVOKING EVHDLR %s", __FILE__, __LINE__,
                         (NULL == chain->evhdlr->name) ?
                         "NULL" : chain->evhdlr->name);
@@ -822,7 +823,6 @@ static void _notify_client_event(int sd, short args, void *cbdata)
             }
         }
     }
-
     if (holdcd) {
         /* we cannot know if everyone who wants this notice has had a chance
          * to register for it - the notice may be coming too early. So cache
@@ -965,19 +965,72 @@ static void _notify_client_event(int sd, short args, void *cbdata)
     chain->source.rank = cd->source.rank;
     /* we always leave space for a callback object and
      * the evhandler name. */
-    chain->ninfo = cd->ninfo + 2;
-    PMIX_INFO_CREATE(chain->info, chain->ninfo);
+    chain->nallocated = cd->ninfo + 2;
+    PMIX_INFO_CREATE(chain->info, chain->nallocated);
     if (0 < cd->ninfo) {
+        chain->ninfo = cd->ninfo;
         /* need to copy the info */
         for (n=0; n < cd->ninfo; n++) {
             PMIX_INFO_XFER(&chain->info[n], &cd->info[n]);
+            if (0 == strncmp(cd->info[n].key, PMIX_EVENT_NON_DEFAULT, PMIX_MAX_KEYLEN)) {
+                cd->nondefault = true;
+                chain->nondefault = true;
+            } else if (0 == strncmp(cd->info[n].key, PMIX_EVENT_CUSTOM_RANGE, PMIX_MAX_KEYLEN)) {
+                /* provides an array of pmix_proc_t identifying the procs
+                 * that are to receive this notification, or a single pmix_proc_t  */
+                if (PMIX_DATA_ARRAY == cd->info[n].value.type &&
+                    NULL != cd->info[n].value.data.darray &&
+                    NULL != cd->info[n].value.data.darray->array) {
+                    cd->ntargets = cd->info[n].value.data.darray->size;
+                    PMIX_PROC_CREATE(cd->targets, cd->ntargets);
+                    memcpy(cd->targets, cd->info[n].value.data.darray->array, cd->ntargets * sizeof(pmix_proc_t));
+                } else if (PMIX_PROC == cd->info[n].value.type) {
+                    cd->ntargets = 1;
+                    PMIX_PROC_CREATE(cd->targets, cd->ntargets);
+                    memcpy(cd->targets, cd->info[n].value.data.proc, sizeof(pmix_proc_t));
+                } else {
+                    /* this is an error */
+                    PMIX_ERROR_LOG(PMIX_ERR_BAD_PARAM);
+                    PMIX_RELEASE(chain);
+                    return;
+                }
+            } else if (0 == strncmp(cd->info[n].key, PMIX_EVENT_AFFECTED_PROC, PMIX_MAX_KEYLEN)) {
+                PMIX_PROC_CREATE(cd->affected, 1);
+                if (NULL == cd->affected) {
+                    PMIX_RELEASE(chain);
+                    return;
+                }
+                cd->naffected = 1;
+                memcpy(cd->affected, cd->info[n].value.data.proc, sizeof(pmix_proc_t));
+                /* need to do the same for chain so it can be correctly processed */
+                PMIX_PROC_CREATE(chain->affected, 1);
+                if (NULL == chain->affected) {
+                    PMIX_RELEASE(chain);
+                    return;
+                }
+                chain->naffected = 1;
+                memcpy(chain->affected, cd->info[n].value.data.proc, sizeof(pmix_proc_t));
+            } else if (0 == strncmp(cd->info[n].key, PMIX_EVENT_AFFECTED_PROCS, PMIX_MAX_KEYLEN)) {
+                cd->naffected = cd->info[n].value.data.darray->size;
+                PMIX_PROC_CREATE(cd->affected, cd->naffected);
+                if (NULL == cd->affected) {
+                    cd->naffected = 0;
+                    PMIX_RELEASE(chain);
+                    return;
+                }
+                memcpy(cd->affected, cd->info[n].value.data.darray->array, cd->naffected * sizeof(pmix_proc_t));
+                /* need to do the same for chain so it can be correctly processed */
+                chain->naffected = cd->info[n].value.data.darray->size;
+                PMIX_PROC_CREATE(chain->affected, chain->naffected);
+                if (NULL == chain->affected) {
+                    chain->naffected = 0;
+                    PMIX_RELEASE(chain);
+                    return;
+                }
+                memcpy(chain->affected, cd->info[n].value.data.darray->array, chain->naffected * sizeof(pmix_proc_t));
+            }
         }
     }
-    /* put the evhandler name tag in the next-to-last element - we
-     * will fill it in as each handler is called */
-    PMIX_INFO_LOAD(&chain->info[chain->ninfo-2], PMIX_EVENT_HDLR_NAME, NULL, PMIX_STRING);
-    /* now put the callback object tag in the last element */
-    PMIX_INFO_LOAD(&chain->info[chain->ninfo-1], PMIX_EVENT_RETURN_OBJECT, NULL, PMIX_POINTER);
     /* process it */
     pmix_invoke_local_event_hdlr(chain);
 
@@ -1138,6 +1191,36 @@ static bool check_range(pmix_range_trkr_t *rng,
     return false;
 }
 
+static bool check_affected(pmix_proc_t *interested, size_t ninterested,
+                           pmix_proc_t *affected, size_t naffected)
+{
+    size_t m, n;
+
+    /* if they didn't restrict their interests, then accept it */
+    if (NULL == interested) {
+        return true;
+    }
+    /* if we weren't given the affected procs, then accept it */
+    if (NULL == affected) {
+        return true;
+    }
+    /* check if the two overlap */
+    for (n=0; n < naffected; n++) {
+        for (m=0; m < ninterested; m++) {
+            if (0 != strncmp(affected[n].nspace, interested[m].nspace, PMIX_MAX_NSLEN)) {
+                continue;
+            }
+            if (PMIX_RANK_WILDCARD == interested[m].rank ||
+                affected[n].rank == interested[m].rank) {
+                return true;
+            }
+        }
+    }
+    /* if we get here, then this proc isn't in range */
+    return false;
+
+}
+
 void pmix_event_timeout_cb(int fd, short flags, void *arg)
 {
     pmix_event_chain_t *ch = (pmix_event_chain_t*)arg;
@@ -1151,7 +1234,8 @@ void pmix_event_timeout_cb(int fd, short flags, void *arg)
     pmix_list_remove_item(&pmix_globals.cached_events, &ch->super);
 
     /* process this event thru the regular channels */
-    if (PMIX_PROC_IS_SERVER(pmix_globals.mypeer)) {
+    if (PMIX_PROC_IS_SERVER(pmix_globals.mypeer) &&
+        !PMIX_PROC_IS_LAUNCHER(pmix_globals.mypeer)) {
         pmix_server_notify_client_of_event(ch->status, &ch->source,
                                            ch->range, ch->info, ch->ninfo,
                                            ch->final_cbfunc, ch->final_cbdata);
@@ -1171,6 +1255,8 @@ static void sevcon(pmix_event_hdlr_t *p)
     p->rng.range = PMIX_RANGE_UNDEF;
     p->rng.procs = NULL;
     p->rng.nprocs = 0;
+    p->affected = NULL;
+    p->naffected = 0;
     p->evhdlr = NULL;
     p->cbobject = NULL;
     p->codes = NULL;
@@ -1186,6 +1272,9 @@ static void sevdes(pmix_event_hdlr_t *p)
     }
     if (NULL != p->rng.procs) {
         free(p->rng.procs);
+    }
+    if (NULL != p->affected) {
+        PMIX_PROC_FREE(p->affected, p->naffected);
     }
     if (NULL != p->codes) {
         free(p->codes);
@@ -1238,8 +1327,11 @@ static void chcon(pmix_event_chain_t *p)
     p->nondefault = false;
     p->endchain = false;
     p->range = PMIX_RANGE_UNDEF;
+    p->affected = NULL;
+    p->naffected = 0;
     p->info = NULL;
     p->ninfo = 0;
+    p->nallocated = 0;
     p->results = NULL;
     p->nresults = 0;
     p->evhdlr = NULL;
@@ -1251,8 +1343,11 @@ static void chdes(pmix_event_chain_t *p)
     if (p->timer_active) {
         pmix_event_del(&p->ev);
     }
+    if (NULL != p->affected) {
+        PMIX_PROC_FREE(p->affected, p->naffected);
+    }
     if (NULL != p->info) {
-        PMIX_INFO_FREE(p->info, p->ninfo);
+        PMIX_INFO_FREE(p->info, p->nallocated);
     }
     if (NULL != p->results) {
         PMIX_INFO_FREE(p->results, p->nresults);

--- a/opal/mca/pmix/pmix3x/pmix/src/event/pmix_event_registration.c
+++ b/opal/mca/pmix/pmix3x/pmix/src/event/pmix_event_registration.c
@@ -80,7 +80,7 @@ static void regevents_cbfunc(struct pmix_peer_t *peer, pmix_ptl_hdr_t *hdr,
     int cnt;
     size_t index = rb->index;
 
-    pmix_output_verbose(2, pmix_globals.debug_output,
+    pmix_output_verbose(2, pmix_client_globals.event_output,
                         "pmix: regevents callback recvd");
 
     /* unpack the status code */
@@ -230,7 +230,7 @@ static pmix_status_t _add_hdlr(pmix_rshift_caddy_t *cd, pmix_list_t *xfer)
     pmix_active_code_t *active;
     pmix_status_t rc;
 
-    pmix_output_verbose(2, pmix_globals.debug_output,
+    pmix_output_verbose(2, pmix_client_globals.event_output,
                         "pmix: _add_hdlr");
 
     /* check to see if we have an active registration on these codes */
@@ -299,15 +299,16 @@ static pmix_status_t _add_hdlr(pmix_rshift_caddy_t *cd, pmix_list_t *xfer)
      * type with our server, or if we have directives, then we need to notify
      * the server - however, don't do this for a v1 server as the event
      * notification system there doesn't work */
-    if (!PMIX_PROC_IS_SERVER(pmix_globals.mypeer) && pmix_globals.connected &&
+    if ((!PMIX_PROC_IS_SERVER(pmix_globals.mypeer) || PMIX_PROC_IS_LAUNCHER(pmix_globals.mypeer)) &&
+        pmix_globals.connected &&
         !PMIX_PROC_IS_V1(pmix_client_globals.myserver) &&
        (need_register || 0 < pmix_list_get_size(xfer))) {
-        pmix_output_verbose(2, pmix_globals.debug_output,
+        pmix_output_verbose(2, pmix_client_globals.event_output,
                             "pmix: _add_hdlr sending to server");
         /* send the directives to the server - we will ack this
          * registration upon return from there */
         if (PMIX_SUCCESS != (rc = _send_to_server(cd2))) {
-            pmix_output_verbose(2, pmix_globals.debug_output,
+            pmix_output_verbose(2, pmix_client_globals.event_output,
                                 "pmix: add_hdlr - pack send_to_server failed status=%d", rc);
             if (NULL != cd2->info) {
                 PMIX_INFO_FREE(cd2->info, cd2->ninfo);
@@ -320,9 +321,10 @@ static pmix_status_t _add_hdlr(pmix_rshift_caddy_t *cd, pmix_list_t *xfer)
 
     /* if we are a server and are registering for events, then we only contact
      * our host if we want environmental events */
-    if (PMIX_PROC_IS_SERVER(pmix_globals.mypeer) && cd->enviro &&
+    if (PMIX_PROC_IS_SERVER(pmix_globals.mypeer) &&
+        !PMIX_PROC_IS_LAUNCHER(pmix_globals.mypeer) && cd->enviro &&
         NULL != pmix_host_server.register_events) {
-        pmix_output_verbose(2, pmix_globals.debug_output,
+        pmix_output_verbose(2, pmix_client_globals.event_output,
                             "pmix: _add_hdlr registering with server");
         if (PMIX_SUCCESS != (rc = pmix_host_server.register_events(cd->codes, cd->ncodes,
                                                                    cd2->info, cd2->ninfo,
@@ -391,16 +393,33 @@ static void check_cached_events(pmix_rshift_caddy_t *cd)
             chain->status = ncd->status;
             (void)strncpy(chain->source.nspace, pmix_globals.myid.nspace, PMIX_MAX_NSLEN);
             chain->source.rank = pmix_globals.myid.rank;
-            /* we already left space for evhandler name plus
-             * a callback object when we cached the notification */
-            chain->ninfo = ncd->ninfo;
-            PMIX_INFO_CREATE(chain->info, chain->ninfo);
+            /* we always leave space for event hdlr name and a callback object */
+            chain->nallocated = ncd->ninfo + 2;
+            PMIX_INFO_CREATE(chain->info, chain->nallocated);
             if (0 < cd->ninfo) {
+                chain->ninfo = ncd->ninfo;
                 /* need to copy the info */
                 for (n=0; n < ncd->ninfo; n++) {
                     PMIX_INFO_XFER(&chain->info[n], &ncd->info[n]);
-                    if (0 == strncmp(chain->info[n].key, PMIX_EVENT_NON_DEFAULT, PMIX_MAX_KEYLEN)) {
+                    if (0 == strncmp(ncd->info[n].key, PMIX_EVENT_NON_DEFAULT, PMIX_MAX_KEYLEN)) {
                         chain->nondefault = true;
+                    } else if (0 == strncmp(ncd->info[n].key, PMIX_EVENT_AFFECTED_PROC, PMIX_MAX_KEYLEN)) {
+                        PMIX_PROC_CREATE(chain->affected, 1);
+                        if (NULL == chain->affected) {
+                            PMIX_RELEASE(chain);
+                            return;
+                        }
+                        chain->naffected = 1;
+                        memcpy(chain->affected, ncd->info[n].value.data.proc, sizeof(pmix_proc_t));
+                    } else if (0 == strncmp(ncd->info[n].key, PMIX_EVENT_AFFECTED_PROCS, PMIX_MAX_KEYLEN)) {
+                        chain->naffected = ncd->info[n].value.data.darray->size;
+                        PMIX_PROC_CREATE(chain->affected, chain->naffected);
+                        if (NULL == chain->affected) {
+                            chain->naffected = 0;
+                            PMIX_RELEASE(chain);
+                            return;
+                        }
+                        memcpy(chain->affected, ncd->info[n].value.data.darray->array, chain->naffected * sizeof(pmix_proc_t));
                     }
                 }
             }
@@ -427,13 +446,13 @@ static void reg_event_hdlr(int sd, short args, void *cbdata)
     pmix_info_caddy_t *ixfer;
     void *cbobject = NULL;
     pmix_data_range_t range = PMIX_RANGE_UNDEF;
-    pmix_proc_t *parray = NULL;
-    size_t nprocs = 0;
+    pmix_proc_t *parray = NULL, *affected = NULL;
+    size_t nprocs = 0, naffected = 0;
 
     /* need to acquire the object from its originating thread */
     PMIX_ACQUIRE_OBJECT(cd);
 
-    pmix_output_verbose(2, pmix_globals.debug_output,
+    pmix_output_verbose(2, pmix_client_globals.event_output,
                         "pmix: register event_hdlr with %d infos", (int)cd->ninfo);
 
     PMIX_CONSTRUCT(&xfer, pmix_list_t);
@@ -482,6 +501,12 @@ static void reg_event_hdlr(int sd, short args, void *cbdata)
             } else if (0 == strncmp(cd->info[n].key, PMIX_EVENT_CUSTOM_RANGE, PMIX_MAX_KEYLEN)) {
                 parray = (pmix_proc_t*)cd->info[n].value.data.darray->array;
                 nprocs = cd->info[n].value.data.darray->size;
+            } else if (0 == strncmp(cd->info[n].key, PMIX_EVENT_AFFECTED_PROC, PMIX_MAX_KEYLEN)) {
+                affected = cd->info[n].value.data.proc;
+                naffected = 1;
+            } else if (0 == strncmp(cd->info[n].key, PMIX_EVENT_AFFECTED_PROCS, PMIX_MAX_KEYLEN)) {
+                affected = (pmix_proc_t*)cd->info[n].value.data.darray->array;
+                naffected = cd->info[n].value.data.darray->size;
             } else {
                 ixfer = PMIX_NEW(pmix_info_caddy_t);
                 ixfer->info = &cd->info[n];
@@ -524,6 +549,17 @@ static void reg_event_hdlr(int sd, short args, void *cbdata)
                 goto ack;
             }
             memcpy(evhdlr->rng.procs, parray, nprocs * sizeof(pmix_proc_t));
+        }
+        if (NULL != affected && 0 < naffected) {
+            evhdlr->naffected = naffected;
+            PMIX_PROC_CREATE(evhdlr->affected, naffected);
+            if (NULL == evhdlr->affected) {
+                index = UINT_MAX;
+                rc = PMIX_ERR_EVENT_REGISTRATION;
+                PMIX_RELEASE(evhdlr);
+                goto ack;
+            }
+            memcpy(evhdlr->affected, affected, naffected * sizeof(pmix_proc_t));
         }
         evhdlr->evhdlr = cd->evhdlr;
         evhdlr->cbobject = cbobject;
@@ -598,6 +634,17 @@ static void reg_event_hdlr(int sd, short args, void *cbdata)
             goto ack;
         }
         memcpy(evhdlr->rng.procs, parray, nprocs * sizeof(pmix_proc_t));
+    }
+    if (NULL != affected && 0 < naffected) {
+        evhdlr->naffected = naffected;
+        PMIX_PROC_CREATE(evhdlr->affected, naffected);
+        if (NULL == evhdlr->affected) {
+            index = UINT_MAX;
+            rc = PMIX_ERR_EVENT_REGISTRATION;
+            PMIX_RELEASE(evhdlr);
+            goto ack;
+        }
+        memcpy(evhdlr->affected, affected, naffected * sizeof(pmix_proc_t));
     }
     evhdlr->evhdlr = cd->evhdlr;
     evhdlr->cbobject = cbobject;
@@ -810,7 +857,7 @@ PMIX_EXPORT void PMIx_Register_event_handler(pmix_status_t codes[], size_t ncode
     cd->evregcbfn = cbfunc;
     cd->cbdata = cbdata;
 
-    pmix_output_verbose(2, pmix_globals.debug_output,
+    pmix_output_verbose(2, pmix_client_globals.event_output,
                         "pmix_register_event_hdlr shifting to progress thread");
 
     PMIX_THREADSHIFT(cd, reg_event_hdlr);
@@ -832,7 +879,8 @@ static void dereg_event_hdlr(int sd, short args, void *cbdata)
 
     /* if I am not the server, and I am connected, then I need
      * to notify the server to remove my registration */
-    if (!PMIX_PROC_IS_SERVER(pmix_globals.mypeer) && pmix_globals.connected) {
+    if ((!PMIX_PROC_IS_SERVER(pmix_globals.mypeer) || PMIX_PROC_IS_LAUNCHER(pmix_globals.mypeer)) &&
+        pmix_globals.connected) {
         msg = PMIX_NEW(pmix_buffer_t);
         PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver,
                          msg, &cmd, 1, PMIX_COMMAND);
@@ -1025,7 +1073,7 @@ PMIX_EXPORT void PMIx_Deregister_event_handler(size_t event_hdlr_ref,
     cd->cbdata = cbdata;
     cd->ref = event_hdlr_ref;
 
-    pmix_output_verbose(2, pmix_globals.debug_output,
+    pmix_output_verbose(2, pmix_client_globals.event_output,
                         "pmix_deregister_event_hdlr shifting to progress thread");
     PMIX_THREADSHIFT(cd, dereg_event_hdlr);
 }

--- a/opal/mca/pmix/pmix3x/pmix/src/include/pmix_globals.h
+++ b/opal/mca/pmix/pmix3x/pmix/src/include/pmix_globals.h
@@ -399,9 +399,28 @@ typedef struct {
     pmix_status_t status;
     pmix_proc_t source;
     pmix_data_range_t range;
+    /* For notification, we use the targets field to track
+     * any custom range of procs that are to receive the
+     * event.
+     */
     pmix_proc_t *targets;
     size_t ntargets;
+    /* When generating a notification, the originator can
+     * specify the range of procs affected by this event.
+     * For example, when creating a JOB_TERMINATED event,
+     * the RM can specify the nspace of the job that has
+     * ended, thus allowing users to provide a different
+     * callback object based on the nspace being monitored.
+     * We use the "affected" field to track these values
+     * when processing the event chain.
+     */
+    pmix_proc_t *affected;
+    size_t naffected;
+    /* track if the event generator stipulates that default
+     * event handlers are/are not to be given the event */
     bool nondefault;
+    /* carry along any other provided info so the individual
+     * handlers can look at it */
     pmix_info_t *info;
     size_t ninfo;
     pmix_buffer_t *buf;

--- a/opal/mca/pmix/pmix3x/pmix/src/mca/bfrops/base/bfrop_base_fns.c
+++ b/opal/mca/pmix/pmix3x/pmix/src/mca/bfrops/base/bfrop_base_fns.c
@@ -175,7 +175,7 @@ void pmix_bfrops_base_value_load(pmix_value_t *v, const void *data,
             memcpy(&(v->data.pinfo->exit_code), &pi->exit_code, sizeof(int));
             break;
         case PMIX_POINTER:
-            memcpy(&(v->data.ptr), data, sizeof(void*));
+            v->data.ptr = (void*)data;
             break;
         case PMIX_ENVAR:
             envar = (pmix_envar_t*)data;
@@ -324,7 +324,7 @@ pmix_status_t pmix_bfrops_base_value_unload(pmix_value_t *kv,
             *sz = sizeof(pmix_proc_state_t);
             break;
         case PMIX_POINTER:
-            memcpy(*data, &(kv->data.ptr), sizeof(void*));
+            *data = (void*)kv->data.ptr;
             *sz = sizeof(void*);
             break;
         case PMIX_DATA_ARRAY:

--- a/opal/mca/pmix/pmix3x/pmix/src/mca/gds/ds12/gds_dstore_component.c
+++ b/opal/mca/pmix/pmix3x/pmix/src/mca/gds/ds12/gds_dstore_component.c
@@ -31,7 +31,7 @@
 #include <src/include/pmix_config.h>
 #include "pmix_common.h"
 
-
+#include "src/include/pmix_globals.h"
 #include "src/mca/gds/gds.h"
 #include "gds_dstore.h"
 
@@ -74,6 +74,13 @@ static int component_open(void)
 
 static int component_query(pmix_mca_base_module_t **module, int *priority)
 {
+    /* launchers cannot use the dstore */
+    if (PMIX_PROC_IS_LAUNCHER(pmix_globals.mypeer)) {
+        *priority = 0;
+        *module = NULL;
+        return PMIX_ERROR;
+    }
+
     *priority = 20;
     *module = (pmix_mca_base_module_t *)&pmix_ds12_module;
     return PMIX_SUCCESS;

--- a/opal/mca/pmix/pmix3x/pmix/src/mca/gds/hash/gds_hash.c
+++ b/opal/mca/pmix/pmix3x/pmix/src/mca/gds/hash/gds_hash.c
@@ -672,7 +672,8 @@ static pmix_status_t hash_register_job_info(struct pmix_peer_t *pr,
     pmix_status_t rc;
     pmix_hash_trkr_t *trk, *t2;
 
-    if (!PMIX_PROC_IS_SERVER(pmix_globals.mypeer)) {
+    if (!PMIX_PROC_IS_SERVER(pmix_globals.mypeer) &&
+        !PMIX_PROC_IS_LAUNCHER(pmix_globals.mypeer)) {
         /* this function is only available on servers */
         PMIX_ERROR_LOG(PMIX_ERR_NOT_SUPPORTED);
         return PMIX_ERR_NOT_SUPPORTED;
@@ -772,7 +773,8 @@ static pmix_status_t hash_store_job_info(const char *nspace,
                         "[%s:%u] pmix:gds:hash store job info for nspace %s",
                         pmix_globals.myid.nspace, pmix_globals.myid.rank, nspace);
 
-    if (PMIX_PROC_IS_SERVER(pmix_globals.mypeer)) {
+    if (PMIX_PROC_IS_SERVER(pmix_globals.mypeer) &&
+        !PMIX_PROC_IS_LAUNCHER(pmix_globals.mypeer)) {
         /* this function is NOT available on servers */
         PMIX_ERROR_LOG(PMIX_ERR_NOT_SUPPORTED);
         return PMIX_ERR_NOT_SUPPORTED;
@@ -1058,10 +1060,10 @@ static pmix_status_t hash_store(const pmix_proc_t *proc,
     pmix_kval_t *kp;
 
     pmix_output_verbose(2, pmix_gds_base_framework.framework_output,
-                        "[%s:%d] gds:hash:hash_store for proc [%s:%d] key %s scope %s",
+                        "[%s:%d] gds:hash:hash_store for proc [%s:%d] key %s type %s scope %s",
                         pmix_globals.myid.nspace, pmix_globals.myid.rank,
                         proc->nspace, proc->rank, kv->key,
-                        PMIx_Scope_string(scope));
+                        PMIx_Data_type_string(kv->value->type), PMIx_Scope_string(scope));
 
     if (NULL == kv->key) {
         return PMIX_ERR_BAD_PARAM;

--- a/opal/mca/pmix/pmix3x/pmix/src/mca/pnet/test/Makefile.am
+++ b/opal/mca/pmix/pmix3x/pmix/src/mca/pnet/test/Makefile.am
@@ -11,7 +11,7 @@
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
 # Copyright (c) 2012      Los Alamos National Security, Inc.  All rights reserved.
-# Copyright (c) 2013-2018 Intel, Inc. All rights reserved.
+# Copyright (c) 2013-2016 Intel, Inc. All rights reserved
 # Copyright (c) 2017      Research Organization for Information Science
 #                         and Technology (RIST). All rights reserved.
 # $COPYRIGHT$

--- a/opal/mca/pmix/pmix3x/pmix/src/mca/ptl/base/base.h
+++ b/opal/mca/pmix/pmix3x/pmix/src/mca/ptl/base/base.h
@@ -100,7 +100,7 @@ PMIX_EXPORT pmix_status_t pmix_ptl_base_cancel_recv(struct pmix_peer_t *peer,
 
 PMIX_EXPORT pmix_status_t pmix_ptl_base_start_listening(pmix_info_t *info, size_t ninfo);
 PMIX_EXPORT void pmix_ptl_base_stop_listening(void);
-
+PMIX_EXPORT pmix_status_t pmix_ptl_base_setup_fork(const pmix_proc_t *proc, char ***env);
 
 /* base support functions */
 PMIX_EXPORT void pmix_ptl_base_send(int sd, short args, void *cbdata);

--- a/opal/mca/pmix/pmix3x/pmix/src/mca/ptl/base/ptl_base_sendrecv.c
+++ b/opal/mca/pmix/pmix3x/pmix/src/mca/ptl/base/ptl_base_sendrecv.c
@@ -80,7 +80,8 @@ void pmix_ptl_base_lost_connection(pmix_peer_t *peer, pmix_status_t err)
     }
     CLOSE_THE_SOCKET(peer->sd);
 
-    if (PMIX_PROC_IS_SERVER(pmix_globals.mypeer)) {
+    if (PMIX_PROC_IS_SERVER(pmix_globals.mypeer) &&
+        !PMIX_PROC_IS_LAUNCHER(pmix_globals.mypeer)) {
         /* if I am a server, then we need to ensure that
          * we properly account for the loss of this client
          * from any local collectives in which it was

--- a/opal/mca/pmix/pmix3x/pmix/src/mca/ptl/base/ptl_base_stubs.c
+++ b/opal/mca/pmix/pmix3x/pmix/src/mca/ptl/base/ptl_base_stubs.c
@@ -30,6 +30,26 @@
 
 #include "src/mca/ptl/base/base.h"
 
+pmix_status_t pmix_ptl_base_setup_fork(const pmix_proc_t *proc, char ***env)
+{
+    pmix_ptl_base_active_t *active;
+    pmix_status_t rc;
+
+    if (!pmix_ptl_globals.initialized) {
+        return PMIX_ERR_INIT;
+    }
+
+    PMIX_LIST_FOREACH(active, &pmix_ptl_globals.actives, pmix_ptl_base_active_t) {
+        if (NULL != active->component->setup_fork) {
+            rc = active->component->setup_fork(proc, env);
+            if (PMIX_SUCCESS != rc && PMIX_ERR_NOT_AVAILABLE != rc) {
+                return rc;
+            }
+        }
+    }
+    return PMIX_SUCCESS;
+}
+
 pmix_status_t pmix_ptl_base_set_notification_cbfunc(pmix_ptl_cbfunc_t cbfunc)
 {
     pmix_ptl_posted_recv_t *req;

--- a/opal/mca/pmix/pmix3x/pmix/src/mca/ptl/ptl.h
+++ b/opal/mca/pmix/pmix3x/pmix/src/mca/ptl/ptl.h
@@ -171,6 +171,10 @@ extern pmix_status_t pmix_ptl_base_connect_to_peer(struct pmix_peer_t* peer,
 typedef pmix_status_t (*pmix_ptl_base_setup_listener_fn_t)(pmix_info_t info[], size_t ninfo,
                                                            bool *need_listener);
 
+/* define a component-level API for obtaining any envars that are to
+ * be passed to client procs upon fork */
+typedef pmix_status_t (*pmix_ptl_base_setup_fork_fn_t)(const pmix_proc_t *proc, char ***env);
+
 /*
  * the standard component data structure
  */
@@ -180,6 +184,8 @@ struct pmix_ptl_base_component_t {
     int                                             priority;
     char*                                           uri;
     pmix_ptl_base_setup_listener_fn_t               setup_listener;
+    pmix_ptl_base_setup_fork_fn_t                   setup_fork;
+
 };
 typedef struct pmix_ptl_base_component_t pmix_ptl_base_component_t;
 

--- a/opal/mca/pmix/pmix3x/pmix/src/mca/ptl/ptl_types.h
+++ b/opal/mca/pmix/pmix3x/pmix/src/mca/ptl/ptl_types.h
@@ -63,14 +63,18 @@ struct pmix_ptl_module_t;
 
 /* define a process type */
 typedef uint16_t pmix_proc_type_t;
-#define PMIX_PROC_UNDEF     0x0000
-#define PMIX_PROC_CLIENT    0x0001
-#define PMIX_PROC_SERVER    0x0002
-#define PMIX_PROC_TOOL      0x0004
-#define PMIX_PROC_V1        0x0008
-#define PMIX_PROC_V20       0x0010
-#define PMIX_PROC_V21       0x0020
-#define PMIX_PROC_V3        0x0040
+#define PMIX_PROC_UNDEF             0x0000
+#define PMIX_PROC_CLIENT            0x0001
+#define PMIX_PROC_SERVER            0x0002
+#define PMIX_PROC_TOOL              0x0004
+#define PMIX_PROC_V1                0x0008
+#define PMIX_PROC_V20               0x0010
+#define PMIX_PROC_V21               0x0020
+#define PMIX_PROC_V3                0x0040
+#define PMIX_PROC_LAUNCHER_ACT      0x1000
+#define PMIX_PROC_LAUNCHER          (PMIX_PROC_TOOL | PMIX_PROC_SERVER | PMIX_PROC_LAUNCHER_ACT)
+#define PMIX_PROC_CLIENT_TOOL_ACT   0x2000
+#define PMIX_PROC_CLIENT_TOOL       (PMIX_PROC_TOOL | PMIX_PROC_CLIENT | PMIX_PROC_CLIENT_TOOL_ACT)
 
 /* defins some convenience macros for testing proc type */
 #define PMIX_PROC_IS_CLIENT(p)      (PMIX_PROC_CLIENT & (p)->proc_type)
@@ -80,6 +84,8 @@ typedef uint16_t pmix_proc_type_t;
 #define PMIX_PROC_IS_V20(p)         (PMIX_PROC_V20 & (p)->proc_type)
 #define PMIX_PROC_IS_V21(p)         (PMIX_PROC_V21 & (p)->proc_type)
 #define PMIX_PROC_IS_V3(p)          (PMIX_PROC_V3 & (p)->proc_type)
+#define PMIX_PROC_IS_LAUNCHER(p)    (PMIX_PROC_LAUNCHER_ACT & (p)->proc_type)
+#define PMIX_PROC_IS_CLIENT_TOOL(p) (PMIX_PROC_CLIENT_TOOL_ACT & (p)->proc_type)
 
 
 /****    MESSAGING STRUCTURES    ****/

--- a/opal/mca/pmix/pmix3x/pmix/src/mca/ptl/tcp/ptl_tcp.c
+++ b/opal/mca/pmix/pmix3x/pmix/src/mca/ptl/tcp/ptl_tcp.c
@@ -51,6 +51,7 @@
 #include "src/util/argv.h"
 #include "src/util/error.h"
 #include "src/util/os_path.h"
+#include "src/util/show_help.h"
 #include "src/mca/bfrops/base/base.h"
 
 #include "src/mca/ptl/base/base.h"
@@ -108,7 +109,7 @@ static pmix_status_t parse_uri_file(char *filename,
                                     char **uri,
                                     char **nspace,
                                     pmix_rank_t *rank);
-static pmix_status_t try_connect(int *sd);
+static pmix_status_t try_connect(char *uri, int *sd);
 static pmix_status_t df_search(char *dirname, char *prefix,
                                int *sd, char **nspace,
                                pmix_rank_t *rank);
@@ -116,15 +117,16 @@ static pmix_status_t df_search(char *dirname, char *prefix,
 static pmix_status_t connect_to_peer(struct pmix_peer_t *peer,
                                      pmix_info_t *info, size_t ninfo)
 {
-    char *evar, **uri, *suri;
+    char *evar, **uri, *suri, *suri2;
     char *filename, *nspace=NULL;
     pmix_rank_t rank = PMIX_RANK_WILDCARD;
-    char *p, *p2;
+    char *p, *p2, *server_nspace = NULL;
     int sd, rc;
     size_t n;
     char myhost[PMIX_MAXHOSTNAMELEN];
     bool system_level = false;
     bool system_level_only = false;
+    bool reconnect = false;
     pid_t pid = 0;
 
     pmix_output_verbose(2, pmix_ptl_base_framework.framework_output,
@@ -137,7 +139,17 @@ static pmix_status_t connect_to_peer(struct pmix_peer_t *peer,
     /* if I am a client, then we need to look for the appropriate
      * connection info in the environment */
     if (PMIX_PROC_IS_CLIENT(pmix_globals.mypeer)) {
-        if (NULL != (evar = getenv("PMIX_SERVER_URI21"))) {
+        if (NULL != (evar = getenv("PMIX_SERVER_URI3"))) {
+            /* we are talking to a v3 server */
+            pmix_client_globals.myserver->proc_type = PMIX_PROC_SERVER | PMIX_PROC_V3;
+            pmix_output_verbose(2, pmix_ptl_base_framework.framework_output,
+                                "V3 SERVER DETECTED");
+            /* must use the v3 bfrops module */
+            pmix_globals.mypeer->nptr->compat.bfrops = pmix_bfrops_base_assign_module("v3");
+            if (NULL == pmix_globals.mypeer->nptr->compat.bfrops) {
+                return PMIX_ERR_INIT;
+            }
+        } else if (NULL != (evar = getenv("PMIX_SERVER_URI21"))) {
             /* we are talking to a v2.1 server */
             pmix_client_globals.myserver->proc_type = PMIX_PROC_SERVER | PMIX_PROC_V21;
             pmix_output_verbose(2, pmix_ptl_base_framework.framework_output,
@@ -163,7 +175,7 @@ static pmix_status_t connect_to_peer(struct pmix_peer_t *peer,
         }
         /* the server will be using the same bfrops as us */
         pmix_client_globals.myserver->nptr->compat.bfrops = pmix_globals.mypeer->nptr->compat.bfrops;
-        /* mark that we are using the V2 protocol */
+        /* mark that we are using the V2 (i.e., tcp) protocol */
         pmix_globals.mypeer->protocol = PMIX_PROTOCOL_V2;
 
         /* the URI consists of the following elements:
@@ -189,96 +201,97 @@ static pmix_status_t connect_to_peer(struct pmix_peer_t *peer,
         nspace = strdup(p);
         rank = strtoull(p2, NULL, 10);
 
-        /* save the URI, but do not overwrite what we may have received from
-         * the info-key directives */
-        if (NULL == mca_ptl_tcp_component.super.uri) {
-            mca_ptl_tcp_component.super.uri = strdup(uri[1]);
-        }
-        pmix_argv_free(uri);
-
         pmix_output_verbose(2, pmix_ptl_base_framework.framework_output,
-                            "ptl:tcp:client attempt connect to %s",
-                            mca_ptl_tcp_component.super.uri);
+                            "ptl:tcp:client attempt connect to %s", uri[1]);
 
         /* go ahead and try to connect */
-        if (PMIX_SUCCESS != (rc = try_connect(&sd))) {
+        if (PMIX_SUCCESS != (rc = try_connect(uri[1], &sd))) {
             free(nspace);
+            pmix_argv_free(uri);
             return rc;
         }
+        pmix_argv_free(uri);
         goto complete;
 
     }
 
     /* get here if we are a tool - check any provided directives
      * to see where they want us to connect to */
+    suri = NULL;
     if (NULL != info) {
         for (n=0; n < ninfo; n++) {
             if (0 == strcmp(info[n].key, PMIX_CONNECT_TO_SYSTEM)) {
                 system_level_only = PMIX_INFO_TRUE(&info[n]);
-            } else if (0 == strcmp(info[n].key, PMIX_CONNECT_SYSTEM_FIRST)) {
+            } else if (0 == strncmp(info[n].key, PMIX_CONNECT_SYSTEM_FIRST, PMIX_MAX_KEYLEN)) {
                 /* try the system-level */
                 system_level = PMIX_INFO_TRUE(&info[n]);
-            } else if (0 == strcmp(info[n].key, PMIX_SERVER_PIDINFO)) {
+            } else if (0 == strncmp(info[n].key, PMIX_SERVER_PIDINFO, PMIX_MAX_KEYLEN)) {
                 pid = info[n].value.data.pid;
-            } else if (0 == strcmp(info[n].key, PMIX_SERVER_URI)) {
-                if (NULL == mca_ptl_tcp_component.super.uri) {
-                    free(mca_ptl_tcp_component.super.uri);
-                }
-                mca_ptl_tcp_component.super.uri = strdup(info[n].value.data.string);
-            } else if (0 == strcmp(info[n].key, PMIX_CONNECT_RETRY_DELAY)) {
+            } else if (0 == strncmp(info[n].key, PMIX_SERVER_NSPACE, PMIX_MAX_KEYLEN)) {
+                server_nspace = strdup(info[n].value.data.string);
+            } else if (0 == strncmp(info[n].key, PMIX_SERVER_URI, PMIX_MAX_KEYLEN)) {
+                suri = strdup(info[n].value.data.string);
+            } else if (0 == strncmp(info[n].key, PMIX_CONNECT_RETRY_DELAY, PMIX_MAX_KEYLEN)) {
                 mca_ptl_tcp_component.wait_to_connect = info[n].value.data.uint32;
-            } else if (0 == strcmp(info[n].key, PMIX_CONNECT_MAX_RETRIES)) {
+            } else if (0 == strncmp(info[n].key, PMIX_CONNECT_MAX_RETRIES, PMIX_MAX_KEYLEN)) {
                 mca_ptl_tcp_component.max_retries = info[n].value.data.uint32;
+            } else if (0 == strncmp(info[n].key, PMIX_RECONNECT_SERVER, PMIX_MAX_KEYLEN)) {
+                reconnect = true;
             }
         }
     }
+    if (NULL == suri && !reconnect && NULL != mca_ptl_tcp_component.super.uri) {
+        suri = strdup(mca_ptl_tcp_component.super.uri);
+    }
+
     /* mark that we are using the V2 protocol */
     pmix_globals.mypeer->protocol = PMIX_PROTOCOL_V2;
     gethostname(myhost, sizeof(myhost));
     /* if we were given a URI via MCA param, then look no further */
-    if (NULL != mca_ptl_tcp_component.super.uri) {
+    if (NULL != suri) {
+        if (NULL != server_nspace) {
+            free(server_nspace);
+        }
         /* if the string starts with "file:", then they are pointing
          * us to a file we need to read to get the URI itself */
-        if (0 == strncmp(mca_ptl_tcp_component.super.uri, "file:", 5)) {
+        if (0 == strncmp(suri, "file:", 5)) {
             pmix_output_verbose(2, pmix_ptl_base_framework.framework_output,
-                                "ptl:tcp:tool getting connection info from %s",
-                                mca_ptl_tcp_component.super.uri);
+                                "ptl:tcp:tool getting connection info from %s", suri);
             nspace = NULL;
-            rc = parse_uri_file(&mca_ptl_tcp_component.super.uri[5], &suri, &nspace, &rank);
+            rc = parse_uri_file(&suri[5], &suri2, &nspace, &rank);
             if (PMIX_SUCCESS != rc) {
                 return PMIX_ERR_UNREACH;
             }
-            free(mca_ptl_tcp_component.super.uri);
-            mca_ptl_tcp_component.super.uri = suri;
+            free(suri);
+            suri = suri2;
         } else {
             /* we need to extract the nspace/rank of the server from the string */
-            p = strchr(mca_ptl_tcp_component.super.uri, ';');
+            p = strchr(suri, ';');
             if (NULL == p) {
                 return PMIX_ERR_BAD_PARAM;
             }
             *p = '\0';
             p++;
-            suri = strdup(p); // save the uri portion
+            suri2 = strdup(p); // save the uri portion
             /* the '.' in the first part of the original string separates
              * nspace from rank */
-            p = strchr(mca_ptl_tcp_component.super.uri, '.');
+            p = strchr(suri, '.');
             if (NULL == p) {
-                free(suri);
+                free(suri2);
                 return PMIX_ERR_BAD_PARAM;
             }
             *p = '\0';
             p++;
-            nspace = strdup(mca_ptl_tcp_component.super.uri);
+            nspace = strdup(suri);
             rank = strtoull(p, NULL, 10);
+            free(suri);
+            suri = suri2;
             /* now update the URI */
-            free(mca_ptl_tcp_component.super.uri);
-            mca_ptl_tcp_component.super.uri = suri;
         }
         pmix_output_verbose(2, pmix_ptl_base_framework.framework_output,
-                            "ptl:tcp:tool attempt connect using given URI %s",
-                            mca_ptl_tcp_component.super.uri);
+                            "ptl:tcp:tool attempt connect using given URI %s", suri);
         /* go ahead and try to connect */
-        if (PMIX_SUCCESS != (rc = try_connect(&sd))) {
+        if (PMIX_SUCCESS != (rc = try_connect(suri, &sd))) {
             if (NULL != nspace) {
                 free(nspace);
             }
@@ -289,6 +302,9 @@ static pmix_status_t connect_to_peer(struct pmix_peer_t *peer,
 
     /* if they gave us a pid, then look for it */
     if (0 != pid) {
+        if (NULL != server_nspace) {
+            free(server_nspace);
+        }
         if (0 > asprintf(&filename, "pmix.%s.tool.%d", myhost, pid)) {
             return PMIX_ERR_NOMEM;
         }
@@ -310,6 +326,30 @@ static pmix_status_t connect_to_peer(struct pmix_peer_t *peer,
         return PMIX_ERR_UNREACH;
     }
 
+    /* if they gave us an nspace, then look for it */
+    if (NULL != server_nspace) {
+        if (0 > asprintf(&filename, "pmix.%s.tool.%s", myhost, server_nspace)) {
+            free(server_nspace);
+            return PMIX_ERR_NOMEM;
+        }
+        free(server_nspace);
+        pmix_output_verbose(2, pmix_ptl_base_framework.framework_output,
+                            "ptl:tcp:tool searching for given session server %s",
+                            filename);
+        nspace = NULL;
+        rc = df_search(mca_ptl_tcp_component.system_tmpdir,
+                       filename, &sd, &nspace, &rank);
+        free(filename);
+        if (PMIX_SUCCESS == rc) {
+            goto complete;
+        }
+        if (NULL != nspace) {
+            free(nspace);
+        }
+        /* since they gave us a specific nspace and we couldn't
+         * connect to it, return an error */
+        return PMIX_ERR_UNREACH;
+    }
 
     /* if they asked for system-level, we start there */
     if (system_level || system_level_only) {
@@ -323,12 +363,10 @@ static pmix_status_t connect_to_peer(struct pmix_peer_t *peer,
         rc = parse_uri_file(filename, &suri, &nspace, &rank);
         free(filename);
         if (PMIX_SUCCESS == rc) {
-            mca_ptl_tcp_component.super.uri = suri;
             pmix_output_verbose(2, pmix_ptl_base_framework.framework_output,
-                                "ptl:tcp:tool attempt connect to system server at %s",
-                                mca_ptl_tcp_component.super.uri);
+                                "ptl:tcp:tool attempt connect to system server at %s", suri);
             /* go ahead and try to connect */
-            if (PMIX_SUCCESS == try_connect(&sd)) {
+            if (PMIX_SUCCESS == try_connect(suri, &sd)) {
                 goto complete;
             }
             free(nspace);
@@ -382,22 +420,27 @@ static pmix_status_t connect_to_peer(struct pmix_peer_t *peer,
     pmix_globals.connected = true;
     pmix_client_globals.myserver->sd = sd;
 
-    /* setup the server info */
-    if (NULL == pmix_client_globals.myserver->info) {
-        pmix_client_globals.myserver->info = PMIX_NEW(pmix_rank_info_t);
-    }
-    if (NULL == pmix_client_globals.myserver->nptr) {
-        pmix_client_globals.myserver->nptr = PMIX_NEW(pmix_nspace_t);
-    }
-    if (NULL == pmix_client_globals.myserver->nptr->nspace) {
+    /* tools setup their server info in try_connect because they
+     * utilize a broader handshake */
+    if (PMIX_PROC_IS_CLIENT(pmix_globals.mypeer)) {
+        /* setup the server info */
+        if (NULL == pmix_client_globals.myserver->info) {
+            pmix_client_globals.myserver->info = PMIX_NEW(pmix_rank_info_t);
+        }
+        if (NULL == pmix_client_globals.myserver->nptr) {
+            pmix_client_globals.myserver->nptr = PMIX_NEW(pmix_nspace_t);
+        }
+        if (NULL != pmix_client_globals.myserver->nptr->nspace) {
+            free(pmix_client_globals.myserver->nptr->nspace);
+        }
         pmix_client_globals.myserver->nptr->nspace = nspace;
-    } else {
-        free(nspace);
-    }
-    if (NULL == pmix_client_globals.myserver->info->pname.nspace) {
+
+        if (NULL != pmix_client_globals.myserver->info->pname.nspace) {
+            free(pmix_client_globals.myserver->info->pname.nspace);
+        }
         pmix_client_globals.myserver->info->pname.nspace = strdup(pmix_client_globals.myserver->nptr->nspace);
+        pmix_client_globals.myserver->info->pname.rank = rank;
     }
-    pmix_client_globals.myserver->info->pname.rank = rank;
 
     pmix_ptl_base_set_nonblocking(sd);
 
@@ -530,9 +573,9 @@ static pmix_status_t parse_uri_file(char *filename,
     p2 = pmix_getline(fp);
     if (NULL == p2) {
         pmix_client_globals.myserver->proc_type = PMIX_PROC_SERVER | PMIX_PROC_V20;
+        pmix_client_globals.myserver->protocol = PMIX_PROTOCOL_V2;
         pmix_output_verbose(2, pmix_ptl_base_framework.framework_output,
                             "V20 SERVER DETECTED");
-        pmix_client_globals.myserver->protocol = PMIX_PROTOCOL_V2;
     } else if (0 == strncmp(p2, "v2.1", strlen("v2.1")) ||
                0 == strncmp(p2, "2.1", strlen("2.1"))) {
         pmix_client_globals.myserver->proc_type = PMIX_PROC_SERVER | PMIX_PROC_V21;
@@ -581,7 +624,7 @@ static pmix_status_t parse_uri_file(char *filename,
     return PMIX_SUCCESS;
 }
 
-static pmix_status_t try_connect(int *sd)
+static pmix_status_t try_connect(char *uri, int *sd)
 {
     char *p, *p2, *host;
     struct sockaddr_in *in;
@@ -591,17 +634,16 @@ static pmix_status_t try_connect(int *sd)
     bool retried = false;
 
     pmix_output_verbose(2, pmix_ptl_base_framework.framework_output,
-                        "pmix:tcp try connect to %s",
-                        mca_ptl_tcp_component.super.uri);
+                        "pmix:tcp try connect to %s", uri);
 
     /* mark that we are the active module for this server */
     pmix_client_globals.myserver->nptr->compat.ptl = &pmix_ptl_tcp_module;
 
     /* setup the path to the daemon rendezvous point */
     memset(&mca_ptl_tcp_component.connection, 0, sizeof(struct sockaddr_storage));
-    if (0 == strncmp(mca_ptl_tcp_component.super.uri, "tcp4", 4)) {
+    if (0 == strncmp(uri, "tcp4", 4)) {
         /* need to skip the tcp4: part */
-        p = strdup(&mca_ptl_tcp_component.super.uri[7]);
+        p = strdup(&uri[7]);
         if (NULL == p) {
             PMIX_ERROR_LOG(PMIX_ERR_NOMEM);
             return PMIX_ERR_NOMEM;
@@ -630,7 +672,7 @@ static pmix_status_t try_connect(int *sd)
         len = sizeof(struct sockaddr_in);
     } else {
         /* need to skip the tcp6: part */
-        p = strdup(&mca_ptl_tcp_component.super.uri[7]);
+        p = strdup(&uri[7]);
         if (NULL == p) {
             PMIX_ERROR_LOG(PMIX_ERR_NOMEM);
             return PMIX_ERR_NOMEM;
@@ -708,12 +750,14 @@ static pmix_status_t send_connect_ack(int sd)
     uid_t euid;
     gid_t egid;
     uint32_t u32;
+    bool self_defined = false;
 
     pmix_output_verbose(2, pmix_ptl_base_framework.framework_output,
                         "pmix:tcp SEND CONNECT ACK");
 
     /* if we are a server, then we shouldn't be here */
-    if (PMIX_PROC_IS_SERVER(pmix_globals.mypeer)) {
+    if (PMIX_PROC_IS_SERVER(pmix_globals.mypeer) &&
+        !PMIX_PROC_IS_LAUNCHER(pmix_globals.mypeer)) {
         return PMIX_ERR_NOT_SUPPORTED;
     }
 
@@ -731,7 +775,6 @@ static pmix_status_t send_connect_ack(int sd)
     PMIX_PSEC_CREATE_CRED(rc, pmix_globals.mypeer,
                           NULL, 0, NULL, 0, &cred);
     if (PMIX_SUCCESS != rc) {
-        pmix_output(0, "OUCH: %d", __LINE__);
         return rc;
     }
 
@@ -741,11 +784,31 @@ static pmix_status_t send_connect_ack(int sd)
     if (PMIX_PROC_IS_CLIENT(pmix_globals.mypeer)) {
         flag = 0;
         /* reserve space for our nspace and rank info */
-        sdsize += strlen(pmix_globals.myid.nspace) + 1 + sizeof(int);
-    } else {
+        sdsize += strlen(pmix_globals.myid.nspace) + 1 + sizeof(uint32_t);
+    } else if (PMIX_PROC_IS_LAUNCHER(pmix_globals.mypeer)) {
+        flag = 2;
+        /* add space for our uid/gid for ACL purposes */
+        sdsize += 2*sizeof(uint32_t);
+        /* if we already have an identifier, we need to pass it */
+        if (0 < strlen(pmix_globals.myid.nspace) &&
+            PMIX_RANK_INVALID != pmix_globals.myid.rank) {
+            sdsize += strlen(pmix_globals.myid.nspace) + 1 + sizeof(uint32_t) + 1;
+            self_defined = true;
+        } else {
+            ++sdsize; // need space for the flag indicating if have id
+        }
+    } else {  // must be a simple tool
         flag = 1;
         /* add space for our uid/gid for ACL purposes */
         sdsize += 2*sizeof(uint32_t);
+        /* if we self-defined an identifier, we need to pass it */
+        if (0 < strlen(pmix_globals.myid.nspace) &&
+            PMIX_RANK_INVALID != pmix_globals.myid.rank) {
+            sdsize += 1 + strlen(pmix_globals.myid.nspace) + 1 + sizeof(uint32_t);
+            self_defined = true;
+        } else {
+            ++sdsize; // need space for the flag indicating if have id
+        }
     }
 
     /* add the name of our active sec module - we selected it
@@ -838,6 +901,25 @@ static pmix_status_t send_connect_ack(int sd)
     memcpy(msg+csize, gds, strlen(gds));
     csize += strlen(gds)+1;
 
+    /* if we are not a client and self-defined an identifier, we need to pass it */
+    if (!PMIX_PROC_IS_CLIENT(pmix_globals.mypeer)) {
+        if (self_defined) {
+            flag = 1;
+            memcpy(msg+csize, &flag, 1);
+            ++csize;
+            memcpy(msg+csize, pmix_globals.myid.nspace, strlen(pmix_globals.myid.nspace));
+            csize += strlen(pmix_globals.myid.nspace)+1;
+            /* again, need to convert */
+            u32 = htonl((uint32_t)pmix_globals.myid.rank);
+            memcpy(msg+csize, &u32, sizeof(uint32_t));
+            csize += sizeof(uint32_t);
+        } else {
+            flag = 0;
+            memcpy(msg+csize, &flag, 1);
+            ++csize;
+        }
+    }
+
     /* send the entire message across */
     if (PMIX_SUCCESS != pmix_ptl_base_send_blocking(sd, msg, sdsize)) {
         free(msg);
@@ -921,12 +1003,23 @@ static pmix_status_t recv_connect_ack(int sd)
             return reply;
         }
         /* recv our nspace */
-        rc = pmix_ptl_base_recv_blocking(sd, (char*)&pmix_globals.myid.nspace, PMIX_MAX_NSLEN+1);
+        rc = pmix_ptl_base_recv_blocking(sd, nspace, PMIX_MAX_NSLEN+1);
         if (PMIX_SUCCESS != rc) {
             return rc;
         }
-        /* our rank is always zero */
-        pmix_globals.myid.rank = 0;
+        /* if we already have our nspace, then just verify it matches */
+        if (0 < strlen(pmix_globals.myid.nspace)) {
+            if (0 != strncmp(pmix_globals.myid.nspace, nspace, PMIX_MAX_NSLEN)) {
+                return PMIX_ERR_INIT;
+            }
+        } else {
+            (void)strncpy(pmix_globals.myid.nspace, nspace, PMIX_MAX_NSLEN);
+        }
+        /* if we already have a rank, then leave it alone */
+        if (PMIX_RANK_INVALID == pmix_globals.myid.rank) {
+            /* our rank is always zero */
+            pmix_globals.myid.rank = 0;
+        }
 
         /* get the server's nspace and rank so we can send to it */
         if (NULL == pmix_client_globals.myserver->info) {
@@ -1026,14 +1119,10 @@ static pmix_status_t df_search(char *dirname, char *prefix,
                                 "pmix:tcp: reading file %s", newdir);
             rc = parse_uri_file(newdir, &suri, &nsp, &rk);
             if (PMIX_SUCCESS == rc) {
-                if (NULL != mca_ptl_tcp_component.super.uri) {
-                    free(mca_ptl_tcp_component.super.uri);
-                }
-                mca_ptl_tcp_component.super.uri = suri;
                 /* go ahead and try to connect */
                 pmix_output_verbose(2, pmix_ptl_base_framework.framework_output,
                                     "pmix:tcp: attempting to connect to %s", suri);
-                if (PMIX_SUCCESS == try_connect(sd)) {
+                if (PMIX_SUCCESS == try_connect(suri, sd)) {
                     (*nspace) = nsp;
                     *rank = rk;
                     closedir(cur_dirp);

--- a/opal/mca/pmix/pmix3x/pmix/src/mca/ptl/tcp/ptl_tcp.h
+++ b/opal/mca/pmix/pmix3x/pmix/src/mca/ptl/tcp/ptl_tcp.h
@@ -46,6 +46,7 @@ typedef struct {
     bool disable_ipv6_family;
     struct sockaddr_storage connection;
     char *session_filename;
+    char *nspace_filename;
     char *system_filename;
     int wait_to_connect;
     int max_retries;

--- a/opal/mca/pmix/pmix3x/pmix/src/mca/ptl/tcp/ptl_tcp_component.c
+++ b/opal/mca/pmix/pmix3x/pmix/src/mca/ptl/tcp/ptl_tcp_component.c
@@ -76,7 +76,7 @@ static int component_register(void);
 static int component_query(pmix_mca_base_module_t **module, int *priority);
 static pmix_status_t setup_listener(pmix_info_t info[], size_t ninfo,
                                     bool *need_listener);
-
+static pmix_status_t setup_fork(const pmix_proc_t *proc, char ***env);
 /*
  * Instantiate the public struct with all of our public information
  * and pointers to our public functions in it
@@ -101,7 +101,8 @@ static pmix_status_t setup_listener(pmix_info_t info[], size_t ninfo,
         },
         .priority = 30,
         .uri = NULL,
-        .setup_listener = setup_listener
+        .setup_listener = setup_listener,
+        .setup_fork = setup_fork
     },
     .session_tmpdir = NULL,
     .system_tmpdir = NULL,
@@ -112,6 +113,7 @@ static pmix_status_t setup_listener(pmix_info_t info[], size_t ninfo,
     .disable_ipv4_family = false,
     .disable_ipv6_family = true,
     .session_filename = NULL,
+    .nspace_filename = NULL,
     .system_filename = NULL,
     .wait_to_connect = 4,
     .max_retries = 2,
@@ -268,6 +270,9 @@ pmix_status_t component_close(void)
     if (NULL != mca_ptl_tcp_component.session_filename) {
         unlink(mca_ptl_tcp_component.session_filename);
     }
+    if (NULL != mca_ptl_tcp_component.nspace_filename) {
+        unlink(mca_ptl_tcp_component.nspace_filename);
+    }
     if (NULL != urifile) {
         /* remove the file */
         unlink(urifile);
@@ -280,6 +285,25 @@ pmix_status_t component_close(void)
 static int component_query(pmix_mca_base_module_t **module, int *priority)
 {
     *module = (pmix_mca_base_module_t*)&pmix_ptl_tcp_module;
+    return PMIX_SUCCESS;
+}
+
+static pmix_status_t setup_fork(const pmix_proc_t *proc, char ***env)
+{
+    char *evar;
+
+    if (0 > asprintf(&evar, "PMIX_SERVER_TMPDIR=%s", mca_ptl_tcp_component.session_tmpdir)) {
+        return PMIX_ERR_NOMEM;
+    }
+    pmix_argv_append_nosize(env, evar);
+    free(evar);
+
+    if (0 > asprintf(&evar, "PMIX_SYSTEM_TMPDIR=%s", mca_ptl_tcp_component.system_tmpdir)) {
+        return PMIX_ERR_NOMEM;
+    }
+    pmix_argv_append_nosize(env, evar);
+    free(evar);
+
     return PMIX_SUCCESS;
 }
 
@@ -504,7 +528,7 @@ static pmix_status_t setup_listener(pmix_info_t info[], size_t ninfo,
     }
 
     lt = PMIX_NEW(pmix_listener_t);
-    lt->varname = strdup("PMIX_SERVER_URI2:PMIX_SERVER_URI21");
+    lt->varname = strdup("PMIX_SERVER_URI3:PMIX_SERVER_URI2:PMIX_SERVER_URI21");
     lt->protocol = PMIX_PROTOCOL_V2;
     lt->ptl = (struct pmix_ptl_module_t*)&pmix_ptl_tcp_module;
     lt->cbfunc = connection_handler;
@@ -516,6 +540,7 @@ static pmix_status_t setup_listener(pmix_info_t info[], size_t ninfo,
         printf("%s:%d socket() failed\n", __FILE__, __LINE__);
         goto sockerror;
     }
+
     /* set reusing ports flag */
     if (setsockopt (lt->socket, SOL_SOCKET, SO_REUSEADDR, (const char *)&flags, sizeof(flags)) < 0) {
         pmix_output(0, "ptl:tcp:create_listen: unable to set the "
@@ -656,6 +681,7 @@ static pmix_status_t setup_listener(pmix_info_t info[], size_t ninfo,
         FILE *fp;
         pid_t mypid;
 
+        /* first output to a file based on pid */
         mypid = getpid();
         if (0 > asprintf(&mca_ptl_tcp_component.session_filename, "%s/pmix.%s.tool.%d",
                          mca_ptl_tcp_component.session_tmpdir, myhost, mypid)) {
@@ -684,10 +710,45 @@ static pmix_status_t setup_listener(pmix_info_t info[], size_t ninfo,
         if (0 != chmod(mca_ptl_tcp_component.session_filename, S_IRUSR | S_IWUSR | S_IRGRP)) {
             PMIX_ERROR_LOG(PMIX_ERR_FILE_OPEN_FAILURE);
             CLOSE_THE_SOCKET(lt->socket);
-            free(mca_ptl_tcp_component.system_filename);
-            mca_ptl_tcp_component.system_filename = NULL;
+            free(mca_ptl_tcp_component.session_filename);
+            mca_ptl_tcp_component.session_filename = NULL;
             goto sockerror;
         }
+
+        /* now output it into a file based on my nspace */
+
+        if (0 > asprintf(&mca_ptl_tcp_component.nspace_filename, "%s/pmix.%s.tool.%s",
+                         mca_ptl_tcp_component.session_tmpdir, myhost, pmix_globals.myid.nspace)) {
+            CLOSE_THE_SOCKET(lt->socket);
+            goto sockerror;
+        }
+        pmix_output_verbose(2, pmix_ptl_base_framework.framework_output,
+                            "WRITING TOOL FILE %s",
+                            mca_ptl_tcp_component.nspace_filename);
+        fp = fopen(mca_ptl_tcp_component.nspace_filename, "w");
+        if (NULL == fp) {
+            pmix_output(0, "Impossible to open the file %s in write mode\n", mca_ptl_tcp_component.nspace_filename);
+            PMIX_ERROR_LOG(PMIX_ERR_FILE_OPEN_FAILURE);
+            CLOSE_THE_SOCKET(lt->socket);
+            free(mca_ptl_tcp_component.nspace_filename);
+            mca_ptl_tcp_component.nspace_filename = NULL;
+            goto sockerror;
+        }
+
+        /* output my URI */
+        fprintf(fp, "%s\n", lt->uri);
+        /* add a flag that indicates we accept v2.1 protocols */
+        fprintf(fp, "%s\n", PMIX_VERSION);
+        fclose(fp);
+        /* set the file mode */
+        if (0 != chmod(mca_ptl_tcp_component.nspace_filename, S_IRUSR | S_IWUSR | S_IRGRP)) {
+            PMIX_ERROR_LOG(PMIX_ERR_FILE_OPEN_FAILURE);
+            CLOSE_THE_SOCKET(lt->socket);
+            free(mca_ptl_tcp_component.nspace_filename);
+            mca_ptl_tcp_component.nspace_filename = NULL;
+            goto sockerror;
+        }
+
     }
 
     /* we need listener thread support */
@@ -824,6 +885,7 @@ static void connection_handler(int sd, short args, void *cbdata)
     pmix_info_t ginfo;
     pmix_proc_type_t proc_type;
     pmix_byte_object_t cred;
+    size_t ninfo;
 
     /* acquire the object */
     PMIX_ACQUIRE_OBJECT(pnd);
@@ -930,6 +992,7 @@ static void connection_handler(int sd, short args, void *cbdata)
 
     if (0 == flag) {
         /* they must be a client, so get their nspace/rank */
+        proc_type = PMIX_PROC_CLIENT;
         PMIX_STRNLEN(msglen, mg, cnt);
         if (msglen < cnt) {
             nspace = mg;
@@ -956,6 +1019,33 @@ static void connection_handler(int sd, short args, void *cbdata)
         }
     } else if (1 == flag) {
         /* they are a tool */
+        proc_type = PMIX_PROC_TOOL;
+        /* extract the uid/gid */
+        if (sizeof(uint32_t) <= cnt) {
+            memcpy(&u32, mg, sizeof(uint32_t));
+            mg += sizeof(uint32_t);
+            cnt -= sizeof(uint32_t);
+            pnd->uid = ntohl(u32);
+        } else {
+           free(msg);
+           /* send an error reply to the client */
+           rc = PMIX_ERR_BAD_PARAM;
+           goto error;
+        }
+        if (sizeof(uint32_t) <= cnt) {
+            memcpy(&u32, mg, sizeof(uint32_t));
+            mg += sizeof(uint32_t);
+            cnt -= sizeof(uint32_t);
+            pnd->gid = ntohl(u32);
+        } else {
+           free(msg);
+           /* send an error reply to the client */
+           rc = PMIX_ERR_BAD_PARAM;
+           goto error;
+        }
+    } else if (2 == flag) {
+        /* they are a launcher */
+        proc_type = PMIX_PROC_LAUNCHER;
         /* extract the uid/gid */
         if (sizeof(uint32_t) <= cnt) {
             memcpy(&u32, mg, sizeof(uint32_t));
@@ -1002,15 +1092,15 @@ static void connection_handler(int sd, short args, void *cbdata)
 
     if (0 == strncmp(version, "2.0", 3)) {
         /* the 2.0 release handshake ends with the version string */
-        proc_type = PMIX_PROC_V20;
+        proc_type = proc_type | PMIX_PROC_V20;
         bfrops = "v20";
         bftype = pmix_bfrops_globals.default_type;  // we can't know any better
         gds = NULL;
     } else {
         if (0 == strncmp(version, "2.1", 3)) {
-            proc_type = PMIX_PROC_V21;
+            proc_type = proc_type | PMIX_PROC_V21;
         } else if (0 == strncmp(version, "3", 1)) {
-            proc_type = PMIX_PROC_V3;
+            proc_type = proc_type | PMIX_PROC_V3;
         } else {
             free(msg);
             rc = PMIX_ERR_NOT_SUPPORTED;
@@ -1059,38 +1149,79 @@ static void connection_handler(int sd, short args, void *cbdata)
     }
 
     /* see if this is a tool connection request */
-    if (1 == flag) {
+    if (0 != flag) {
         /* does the server support tool connections? */
         if (NULL == pmix_host_server.tool_connected) {
             /* send an error reply to the client */
             rc = PMIX_ERR_NOT_SUPPORTED;
             goto error;
         }
-        /* setup the info array to pass the relevant info
-         * to the server - starting with the version, if present */
-        n = 0;
-        PMIX_STRNLEN(msglen, mg, cnt);
-        if (msglen < cnt) {
-            pnd->ninfo = 4;
-            PMIX_INFO_CREATE(pnd->info, pnd->ninfo);
-            (void)strncpy(pnd->info[n].key, PMIX_VERSION_INFO, PMIX_MAX_KEYLEN);
-            pnd->info[n].value.type = PMIX_STRING;
-            pnd->info[n].value.data.string = strdup(mg);
-            ++n;
+
+        if (PMIX_PROC_V3 & proc_type) {
+            /* the caller will have provided a flag indicating
+             * whether or not they have an assigned nspace/rank */
+            if (cnt < 1) {
+                PMIX_ERROR_LOG(PMIX_ERR_BAD_PARAM);
+                free(msg);
+                /* send an error reply to the client */
+                rc = PMIX_ERR_BAD_PARAM;
+                goto error;
+            }
+            memcpy(&flag, mg, 1);
+            ++mg;
+            --cnt;
+            if (flag) {
+                PMIX_STRNLEN(msglen, mg, cnt);
+                if (msglen < cnt) {
+                    nspace = mg;
+                    mg += strlen(nspace) + 1;
+                    cnt -= strlen(nspace) + 1;
+                } else {
+                    free(msg);
+                    /* send an error reply to the client */
+                    rc = PMIX_ERR_BAD_PARAM;
+                    goto error;
+                }
+                if (sizeof(pmix_rank_t) <= cnt) {
+                    /* have to convert this to host order */
+                    memcpy(&u32, mg, sizeof(uint32_t));
+                    rank = ntohl(u32);
+                    mg += sizeof(uint32_t);
+                    cnt -= sizeof(uint32_t);
+                } else {
+                    free(msg);
+                    /* send an error reply to the client */
+                    rc = PMIX_ERR_BAD_PARAM;
+                    goto error;
+                }
+                pnd->ninfo = 5;
+            } else {
+                pnd->ninfo = 3;
+            }
         } else {
             pnd->ninfo = 3;
-            PMIX_INFO_CREATE(pnd->info, pnd->ninfo);
         }
+
+        /* setup the info array to pass the relevant info
+         * to the server */
+        n = 0;
+        PMIX_INFO_CREATE(pnd->info, pnd->ninfo);
+        /* provide the version */
+        PMIX_INFO_LOAD(&pnd->info[n], PMIX_VERSION_INFO, version, PMIX_STRING);
+        ++n;
         /* provide the user id */
-        (void)strncpy(pnd->info[n].key, PMIX_USERID, PMIX_MAX_KEYLEN);
-        pnd->info[n].value.type = PMIX_UINT32;
-        pnd->info[n].value.data.uint32 = pnd->uid;
+        PMIX_INFO_LOAD(&pnd->info[n], PMIX_USERID, &pnd->uid, PMIX_UINT32);
         ++n;
         /* and the group id */
-        (void)strncpy(pnd->info[n].key, PMIX_GRPID, PMIX_MAX_KEYLEN);
-        pnd->info[n].value.type = PMIX_UINT32;
-        pnd->info[n].value.data.uint32 = pnd->gid;
+        PMIX_INFO_LOAD(&pnd->info[n], PMIX_GRPID, &pnd->gid, PMIX_UINT32);
         ++n;
+        /* if we have it, pass along our ID */
+        if (flag) {
+            PMIX_INFO_LOAD(&pnd->info[n], PMIX_NSPACE, nspace, PMIX_STRING);
+            ++n;
+            PMIX_INFO_LOAD(&pnd->info[n], PMIX_RANK, &rank, PMIX_PROC_RANK);
+            ++n;
+        }
         /* pass along the proc_type */
         pnd->proc_type = proc_type;
         /* pass along the bfrop, buffer_type, and sec fields so
@@ -1106,7 +1237,8 @@ static void connection_handler(int sd, short args, void *cbdata)
         /* release the msg */
         free(msg);
         /* request an nspace for this requestor - it will
-         * automatically be assigned rank=0 */
+         * automatically be assigned rank=0 if the rank
+         * isn't already known */
         pmix_host_server.tool_connected(pnd->info, pnd->ninfo, cnct_cbfunc, pnd);
         return;
     }
@@ -1156,7 +1288,7 @@ static void connection_handler(int sd, short args, void *cbdata)
         return;
     }
     /* mark that this peer is a client of the given type */
-    peer->proc_type = PMIX_PROC_CLIENT | proc_type;
+    peer->proc_type = proc_type;
     /* save the protocol */
     peer->protocol = pnd->protocol;
     /* add in the nspace pointer */
@@ -1414,7 +1546,7 @@ static void process_cbfunc(int sd, short args, void *cbdata)
         return;
     }
     /* mark the peer proc type */
-    peer->proc_type = PMIX_PROC_TOOL | pnd->proc_type;
+    peer->proc_type = pnd->proc_type;
     /* save the protocol */
     peer->protocol = pnd->protocol;
     /* add in the nspace pointer */

--- a/opal/mca/pmix/pmix3x/pmix/src/runtime/help-pmix-runtime.txt
+++ b/opal/mca/pmix/pmix3x/pmix/src/runtime/help-pmix-runtime.txt
@@ -67,3 +67,23 @@ A received msg header indicates a size that is too large:
 
 If you believe this msg is legitimate, please increase the
 max msg size via the ptl_base_max_msg_size parameter.
+#
+[tool:no-server]
+A call was made to PMIx_tool_connect_to_server, but no information
+was given as to which server the tool should be connected. Accepted
+attributes include:
+
+  - PMIX_CONNECT_TO_SYSTEM: connect solely to the system server
+
+  - PMIX_CONNECT_SYSTEM_FIRST: a request to use the system server first,
+      if existing, and then look for the server specified in a different
+      attribute
+
+  - PMIX_SERVER_URI: connect to the server at the given URI
+
+  - PMIX_SERVER_NSPACE: connect to the server of a given nspace
+
+  - PMIX_SERVER_PIDINFO: connect to a server embedded in the process with
+      the given pid
+
+Please correct your program and try again.

--- a/opal/mca/pmix/pmix3x/pmix/src/runtime/pmix_init.c
+++ b/opal/mca/pmix/pmix3x/pmix/src/runtime/pmix_init.c
@@ -151,7 +151,8 @@ int pmix_rte_init(pmix_proc_type_t type,
     }
 
     /* setup the globals structure */
-    memset(&pmix_globals.myid, 0, sizeof(pmix_proc_t));
+    memset(&pmix_globals.myid.nspace, 0, PMIX_MAX_NSLEN+1);
+    pmix_globals.myid.rank = PMIX_RANK_INVALID;
     PMIX_CONSTRUCT(&pmix_globals.events, pmix_events_t);
     pmix_globals.event_window.tv_sec = pmix_event_caching_window;
     pmix_globals.event_window.tv_usec = 0;

--- a/opal/mca/pmix/pmix3x/pmix/src/server/pmix_server_ops.h
+++ b/opal/mca/pmix/pmix3x/pmix/src/server/pmix_server_ops.h
@@ -282,6 +282,12 @@ pmix_status_t pmix_server_event_recvd_from_client(pmix_peer_t *peer,
                                                   void *cbdata);
 void pmix_server_execute_collective(int sd, short args, void *cbdata);
 
+pmix_status_t pmix_server_initialize(void);
+
+void pmix_server_message_handler(struct pmix_peer_t *pr,
+                                 pmix_ptl_hdr_t *hdr,
+                                 pmix_buffer_t *buf, void *cbdata);
+
 PMIX_EXPORT extern pmix_server_module_t pmix_host_server;
 PMIX_EXPORT extern pmix_server_globals_t pmix_server_globals;
 

--- a/opal/mca/pmix/pmix3x/pmix/src/threads/threads.h
+++ b/opal/mca/pmix/pmix3x/pmix/src/threads/threads.h
@@ -65,6 +65,7 @@ typedef pthread_cond_t pmix_condition_t;
 #define PMIX_CONDITION_STATIC_INIT PTHREAD_COND_INITIALIZER
 
 typedef struct {
+    pmix_status_t status;
     pmix_mutex_t mutex;
     pmix_condition_t cond;
     volatile bool active;

--- a/opal/mca/pmix/pmix3x/pmix/src/tool/pmix_tool.c
+++ b/opal/mca/pmix/pmix3x/pmix/src/tool/pmix_tool.c
@@ -63,6 +63,7 @@
 #include "src/util/error.h"
 #include "src/util/hash.h"
 #include "src/util/output.h"
+#include "src/util/show_help.h"
 #include "src/runtime/pmix_progress_threads.h"
 #include "src/runtime/pmix_rte.h"
 #include "src/mca/bfrops/base/base.h"
@@ -71,6 +72,7 @@
 #include "src/mca/psec/psec.h"
 #include "src/include/pmix_globals.h"
 #include "src/common/pmix_iof.h"
+#include "src/server/pmix_server_ops.h"
 
 #define PMIX_MAX_RETRIES 10
 
@@ -146,9 +148,9 @@ static void pmix_tool_notify_recv(struct pmix_peer_t *peer,
         goto error;
     }
 
-    /* we always leave space for a callback object */
-    chain->ninfo = ninfo + 1;
-    PMIX_INFO_CREATE(chain->info, chain->ninfo);
+    /* we always leave space for event hdlr name and a callback object */
+    chain->nallocated = ninfo + 2;
+    PMIX_INFO_CREATE(chain->info, chain->nallocated);
     if (NULL == chain->info) {
         PMIX_ERROR_LOG(PMIX_ERR_NOMEM);
         PMIX_RELEASE(chain);
@@ -156,6 +158,7 @@ static void pmix_tool_notify_recv(struct pmix_peer_t *peer,
     }
 
     if (0 < ninfo) {
+        chain->ninfo = ninfo;
         cnt = ninfo;
         PMIX_BFROPS_UNPACK(rc, pmix_client_globals.myserver,
                            buf, chain->info, &cnt, PMIX_INFO);
@@ -172,8 +175,6 @@ static void pmix_tool_notify_recv(struct pmix_peer_t *peer,
             }
         }
     }
-    /* now put the callback object tag in the last element */
-    PMIX_INFO_LOAD(&chain->info[ninfo], PMIX_EVENT_RETURN_OBJECT, NULL, PMIX_POINTER);
 
     pmix_output_verbose(2, pmix_client_globals.event_output,
                         "[%s:%d] pmix:tool_notify_recv - processing event %d, calling errhandler",
@@ -182,7 +183,7 @@ static void pmix_tool_notify_recv(struct pmix_peer_t *peer,
     pmix_invoke_local_event_hdlr(chain);
     return;
 
-  error:
+    error:
     /* we always need to return */
     pmix_output_verbose(2, pmix_client_globals.event_output,
                         "pmix:tool_notify_recv - unpack error status =%d, calling def errhandler", rc);
@@ -239,14 +240,47 @@ static void tool_iof_handler(struct pmix_peer_t *pr,
     PMIX_BYTE_OBJECT_DESTRUCT(&bo);
 }
 
+/* callback to receive job info */
+static void job_data(struct pmix_peer_t *pr,
+                     pmix_ptl_hdr_t *hdr,
+                     pmix_buffer_t *buf, void *cbdata)
+{
+    pmix_status_t rc;
+    char *nspace;
+    int32_t cnt = 1;
+    pmix_cb_t *cb = (pmix_cb_t*)cbdata;
+
+    /* unpack the nspace - should be same as our own */
+    PMIX_BFROPS_UNPACK(rc, pmix_client_globals.myserver,
+                       buf, &nspace, &cnt, PMIX_STRING);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        cb->status = PMIX_ERROR;
+        PMIX_POST_OBJECT(cb);
+        PMIX_WAKEUP_THREAD(&cb->lock);
+        return;
+    }
+
+    /* decode it */
+    PMIX_GDS_STORE_JOB_INFO(cb->status,
+                            pmix_client_globals.myserver,
+                            nspace, buf);
+    cb->status = PMIX_SUCCESS;
+    PMIX_POST_OBJECT(cb);
+    PMIX_WAKEUP_THREAD(&cb->lock);
+}
+
 PMIX_EXPORT int PMIx_tool_init(pmix_proc_t *proc,
                                pmix_info_t info[], size_t ninfo)
 {
     pmix_kval_t *kptr;
     pmix_status_t rc;
     char hostname[PMIX_MAX_NSLEN];
-    bool found, do_not_connect = false;
+    char *evar, *nspace;
+    pmix_rank_t rank;
+    bool found, gdsfound, do_not_connect = false;
     bool nspace_given = false;
+    bool nspace_in_enviro = false;
     bool rank_given = false;
     bool fwd_stdin = false;
     pmix_info_t ginfo;
@@ -254,6 +288,10 @@ PMIX_EXPORT int PMIx_tool_init(pmix_proc_t *proc,
     pmix_ptl_posted_recv_t *rcv;
     pmix_proc_t wildcard;
     int fd;
+    pmix_proc_type_t ptype;
+    pmix_cb_t cb;
+    pmix_buffer_t *req;
+    pmix_cmd_t cmd = PMIX_REQ_CMD;
 
     PMIX_ACQUIRE_THREAD(&pmix_global_lock);
 
@@ -265,7 +303,7 @@ PMIX_EXPORT int PMIx_tool_init(pmix_proc_t *proc,
         /* since we have been called before, the nspace and
          * rank should be known. So return them here if
          * requested */
-         if (NULL != proc) {
+        if (NULL != proc) {
             (void)strncpy(proc->nspace, pmix_globals.myid.nspace, PMIX_MAX_NSLEN);
             proc->rank = pmix_globals.myid.rank;
         }
@@ -274,23 +312,97 @@ PMIX_EXPORT int PMIx_tool_init(pmix_proc_t *proc,
         return PMIX_SUCCESS;
     }
 
-    /* if we were given an nspace in the environment, then we
-     * must have been spawned by a PMIx server - so even though
-     * we technically will operate as a tool, we are actually
-     * a "client" of the PMIx server and should connect that way */
-    if (NULL != getenv("PMIX_NAMESPACE")) {
+    /* parse the input directives */
+    gdsfound = false;
+    ptype = PMIX_PROC_TOOL;
+    if (NULL != info) {
+        for (n=0; n < ninfo; n++) {
+            if (0 == strncmp(info[n].key, PMIX_GDS_MODULE, PMIX_MAX_KEYLEN)) {
+                PMIX_INFO_LOAD(&ginfo, PMIX_GDS_MODULE, info[n].value.data.string, PMIX_STRING);
+                gdsfound = true;
+            } else if (0 == strncmp(info[n].key, PMIX_TOOL_DO_NOT_CONNECT, PMIX_MAX_KEYLEN)) {
+                do_not_connect = PMIX_INFO_TRUE(&info[n]);
+            } else if (0 == strncmp(info[n].key, PMIX_TOOL_NSPACE, PMIX_MAX_KEYLEN)) {
+                nspace = strdup(info[n].value.data.string);
+                nspace_given = true;
+            } else if (0 == strncmp(info[n].key, PMIX_TOOL_RANK, PMIX_MAX_KEYLEN)) {
+                rank = info[n].value.data.rank;
+                rank_given = true;
+            } else if (0 == strncmp(info[n].key, PMIX_FWD_STDIN, PMIX_MAX_KEYLEN)) {
+                /* they want us to forward our stdin to someone */
+                fwd_stdin = true;
+            } else if (0 == strncmp(info[n].key, PMIX_LAUNCHER, PMIX_MAX_KEYLEN)) {
+                ptype = PMIX_PROC_LAUNCHER;
+            }
+        }
+    }
+    if ((nspace_given && !rank_given) ||
+        (!nspace_given && rank_given)) {
+        /* can't have one and not the other */
+        PMIX_ERROR_LOG(PMIX_ERR_BAD_PARAM);
         PMIX_RELEASE_THREAD(&pmix_global_lock);
-        return PMIx_Init(proc, info, ninfo);
+        return rc;
+    }
+
+    /* if we were not passed an nspace in the info keys,
+     * check to see if we were given one in the env - this
+     * will be the case when we are launched by a PMIx-enabled
+     * daemon */
+    if (!nspace_given) {
+        if (NULL != (evar = getenv("PMIX_NAMESPACE"))) {
+            nspace = strdup(evar);
+            nspace_in_enviro = true;
+        }
+    }
+    /* also look for the rank - it normally is zero, but if we
+     * were launched, then it might have been as part of a
+     * multi-process tool */
+    if (!rank_given) {
+        if (NULL != (evar = getenv("PMIX_RANK"))) {
+            rank = strtol(evar, NULL, 10);
+            if (!nspace_in_enviro) {
+                /* this is an error - we can't have one and not
+                 * the other */
+                PMIX_ERROR_LOG(PMIX_ERR_BAD_PARAM);
+                PMIX_RELEASE_THREAD(&pmix_global_lock);
+                return rc;
+            }
+            /* flag that this tool is also a client */
+            ptype |= PMIX_PROC_CLIENT_TOOL;
+        } else if (nspace_in_enviro) {
+            /* this is an error - we can't have one and not
+             * the other */
+            PMIX_ERROR_LOG(PMIX_ERR_BAD_PARAM);
+            PMIX_RELEASE_THREAD(&pmix_global_lock);
+            return rc;
+        }
     }
 
     /* setup the runtime - this init's the globals,
      * opens and initializes the required frameworks */
-    if (PMIX_SUCCESS != (rc = pmix_rte_init(PMIX_PROC_TOOL, info, ninfo,
+    if (PMIX_SUCCESS != (rc = pmix_rte_init(ptype, info, ninfo,
                                             pmix_tool_notify_recv))) {
         PMIX_ERROR_LOG(rc);
         PMIX_RELEASE_THREAD(&pmix_global_lock);
         return rc;
     }
+    /* if we were given a name, then set it now */
+    if (nspace_given || nspace_in_enviro) {
+        (void)strncpy(pmix_globals.myid.nspace, nspace, PMIX_MAX_NSLEN);
+        free(nspace);
+        pmix_globals.myid.rank = rank;
+    }
+
+    /* if we are a launcher, then we also need to act as a server,
+     * so setup the server-related structures here */
+    if (PMIX_PROC_IS_LAUNCHER(pmix_globals.mypeer)) {
+        if (PMIX_SUCCESS != (rc = pmix_server_initialize())) {
+            PMIX_ERROR_LOG(rc);
+            PMIX_RELEASE_THREAD(&pmix_global_lock);
+            return rc;
+        }
+    }
+
     /* setup the IO Forwarding recv */
     rcv = PMIX_NEW(pmix_ptl_posted_recv_t);
     rcv->tag = PMIX_PTL_TAG_IOF;
@@ -299,31 +411,60 @@ PMIX_EXPORT int PMIx_tool_init(pmix_proc_t *proc,
     pmix_list_append(&pmix_ptl_globals.posted_recvs, &rcv->super);
 
 
+    /* setup the globals */
     PMIX_CONSTRUCT(&pmix_client_globals.pending_requests, pmix_list_t);
     PMIX_CONSTRUCT(&pmix_client_globals.peers, pmix_pointer_array_t);
     pmix_pointer_array_init(&pmix_client_globals.peers, 1, INT_MAX, 1);
     pmix_client_globals.myserver = PMIX_NEW(pmix_peer_t);
+    if (NULL == pmix_client_globals.myserver) {
+        PMIX_RELEASE_THREAD(&pmix_global_lock);
+        return PMIX_ERR_NOMEM;
+    }
     pmix_client_globals.myserver->nptr = PMIX_NEW(pmix_nspace_t);
+    if (NULL == pmix_client_globals.myserver->nptr) {
+        PMIX_RELEASE(pmix_client_globals.myserver);
+        PMIX_RELEASE_THREAD(&pmix_global_lock);
+        return PMIX_ERR_NOMEM;
+    }
+    pmix_client_globals.myserver->info = PMIX_NEW(pmix_rank_info_t);
+    if (NULL == pmix_client_globals.myserver->info) {
+        PMIX_RELEASE(pmix_client_globals.myserver);
+        PMIX_RELEASE_THREAD(&pmix_global_lock);
+        return PMIX_ERR_NOMEM;
+    }
 
     pmix_output_verbose(2, pmix_globals.debug_output,
                         "pmix: init called");
 
-    /* select our bfrops compat module */
-    pmix_globals.mypeer->nptr->compat.bfrops = pmix_bfrops_base_assign_module(NULL);
-    if (NULL == pmix_globals.mypeer->nptr->compat.bfrops) {
-        PMIX_RELEASE_THREAD(&pmix_global_lock);
-        return PMIX_ERR_INIT;
+    if (PMIX_PROC_IS_CLIENT(pmix_globals.mypeer)) {
+        /* if we are a client, then we need to pickup the
+         * rest of the envar-based server assignments */
+        pmix_globals.pindex = -1;
+        /* setup a rank_info object for us */
+        pmix_globals.mypeer->info = PMIX_NEW(pmix_rank_info_t);
+        if (NULL == pmix_globals.mypeer->info) {
+            PMIX_RELEASE_THREAD(&pmix_global_lock);
+            return PMIX_ERR_NOMEM;
+        }
+        pmix_globals.mypeer->info->pname.nspace = strdup(pmix_globals.myid.nspace);
+        pmix_globals.mypeer->info->pname.rank = pmix_globals.myid.rank;
+        /* our bfrops module will be set when we connect to the server */
+    } else {
+        /* select our bfrops compat module */
+        pmix_globals.mypeer->nptr->compat.bfrops = pmix_bfrops_base_assign_module(NULL);
+        if (NULL == pmix_globals.mypeer->nptr->compat.bfrops) {
+            PMIX_RELEASE_THREAD(&pmix_global_lock);
+            return PMIX_ERR_INIT;
+        }
+        /* the server will be using the same */
+        pmix_client_globals.myserver->nptr->compat.bfrops = pmix_globals.mypeer->nptr->compat.bfrops;
     }
-    /* the server will be using the same */
-    pmix_client_globals.myserver->nptr->compat.bfrops = pmix_globals.mypeer->nptr->compat.bfrops;
 
-    /* set the buffer type */
-    pmix_globals.mypeer->nptr->compat.type = pmix_bfrops_globals.default_type;
-    /* the server will be using the same */
-    pmix_client_globals.myserver->nptr->compat.type = pmix_globals.mypeer->nptr->compat.type;
-
-    /* select our psec compat module */
-    pmix_globals.mypeer->nptr->compat.psec = pmix_psec_base_assign_module(NULL);
+    /* select our psec compat module - the selection may be based
+     * on the corresponding envars that should have been passed
+     * to us at launch */
+    evar = getenv("PMIX_SECURITY_MODE");
+    pmix_globals.mypeer->nptr->compat.psec = pmix_psec_base_assign_module(evar);
     if (NULL == pmix_globals.mypeer->nptr->compat.psec) {
         PMIX_RELEASE_THREAD(&pmix_global_lock);
         return PMIX_ERR_INIT;
@@ -331,38 +472,25 @@ PMIX_EXPORT int PMIx_tool_init(pmix_proc_t *proc,
     /* the server will be using the same */
     pmix_client_globals.myserver->nptr->compat.psec = pmix_globals.mypeer->nptr->compat.psec;
 
-    /* select the gds compat module */
-    pmix_client_globals.myserver->nptr->compat.gds = pmix_gds_base_assign_module(NULL, 0);
-    if (NULL == pmix_client_globals.myserver->nptr->compat.gds) {
-        PMIX_INFO_DESTRUCT(&ginfo);
-        PMIX_RELEASE_THREAD(&pmix_global_lock);
-        return PMIX_ERR_INIT;
+    /* set the buffer type - the selection will be based
+     * on the corresponding envars that should have been passed
+     * to us at launch */
+    evar = getenv("PMIX_BFROP_BUFFER_TYPE");
+    if (NULL == evar) {
+        /* just set to our default */
+        pmix_globals.mypeer->nptr->compat.type = pmix_bfrops_globals.default_type;
+    } else if (0 == strcmp(evar, "PMIX_BFROP_BUFFER_FULLY_DESC")) {
+        pmix_globals.mypeer->nptr->compat.type = PMIX_BFROP_BUFFER_FULLY_DESC;
+    } else {
+        pmix_globals.mypeer->nptr->compat.type = PMIX_BFROP_BUFFER_NON_DESC;
     }
+    /* the server will be using the same */
+    pmix_client_globals.myserver->nptr->compat.type = pmix_globals.mypeer->nptr->compat.type;
 
-    /* now select a GDS module for our own internal use - the user may
+    /* select a GDS module for our own internal use - the user may
      * have passed down a directive for this purpose. If they did, then
      * use it. Otherwise, we want the "hash" module */
-    found = false;
-    if (NULL != info) {
-        for (n=0; n < ninfo; n++) {
-            if (0 == strncmp(info[n].key, PMIX_GDS_MODULE, PMIX_MAX_KEYLEN)) {
-                PMIX_INFO_LOAD(&ginfo, PMIX_GDS_MODULE, info[n].value.data.string, PMIX_STRING);
-                found = true;
-            } else if (0 == strncmp(info[n].key, PMIX_TOOL_DO_NOT_CONNECT, PMIX_MAX_KEYLEN)) {
-                do_not_connect = PMIX_INFO_TRUE(&info[n]);
-            } else if (0 == strncmp(info[n].key, PMIX_TOOL_NSPACE, PMIX_MAX_KEYLEN)) {
-                (void)strncpy(pmix_globals.myid.nspace, info[n].value.data.string, PMIX_MAX_NSLEN);
-                nspace_given = true;
-            } else if (0 == strncmp(info[n].key, PMIX_TOOL_RANK, PMIX_MAX_KEYLEN)) {
-                pmix_globals.myid.rank = info[n].value.data.rank;
-                rank_given = true;
-            } else if (0 == strncmp(info[n].key, PMIX_FWD_STDIN, PMIX_MAX_KEYLEN)) {
-                /* they want us to forward our stdin to someone */
-                fwd_stdin = true;
-            }
-        }
-    }
-    if (!found) {
+    if (!gdsfound) {
         PMIX_INFO_LOAD(&ginfo, PMIX_GDS_MODULE, "hash", PMIX_STRING);
     }
     pmix_globals.mypeer->nptr->compat.gds = pmix_gds_base_assign_module(&ginfo, 1);
@@ -372,6 +500,22 @@ PMIX_EXPORT int PMIx_tool_init(pmix_proc_t *proc,
         return PMIX_ERR_INIT;
     }
     PMIX_INFO_DESTRUCT(&ginfo);
+    /* select the gds compat module we will use to interact with
+     * our server- the selection will be based
+     * on the corresponding envars that should have been passed
+     * to us at launch */
+    evar = getenv("PMIX_GDS_MODULE");
+    if (NULL != evar) {
+        PMIX_INFO_LOAD(&ginfo, PMIX_GDS_MODULE, evar, PMIX_STRING);
+        pmix_client_globals.myserver->nptr->compat.gds = pmix_gds_base_assign_module(&ginfo, 1);
+        PMIX_INFO_DESTRUCT(&ginfo);
+    } else {
+        pmix_client_globals.myserver->nptr->compat.gds = pmix_gds_base_assign_module(NULL, 0);
+    }
+    if (NULL == pmix_client_globals.myserver->nptr->compat.gds) {
+        PMIX_RELEASE_THREAD(&pmix_global_lock);
+        return PMIX_ERR_INIT;
+    }
 
     if (do_not_connect) {
         /* ensure we mark that we are not connected */
@@ -382,19 +526,23 @@ PMIX_EXPORT int PMIx_tool_init(pmix_proc_t *proc,
             return PMIX_ERR_INIT;
         }
     } else {
-        /* connect to the server - returns job info if successful */
+        /* connect to the server */
         rc = pmix_ptl_base_connect_to_peer((struct pmix_peer_t*)pmix_client_globals.myserver, info, ninfo);
         if (PMIX_SUCCESS != rc){
             PMIX_RELEASE_THREAD(&pmix_global_lock);
             return rc;
         }
     }
-    /* Success, so copy the nspace and rank to the proc struct they gave us */
-    (void)strncpy(proc->nspace, pmix_globals.myid.nspace, PMIX_MAX_NSLEN);
-    proc->rank = pmix_globals.myid.rank;
+    if (!nspace_given) {
+        /* Success, so copy the nspace and rank to the proc struct they gave us */
+        (void)strncpy(proc->nspace, pmix_globals.myid.nspace, PMIX_MAX_NSLEN);
+    }
+    if (!rank_given) {
+        proc->rank = pmix_globals.myid.rank;
+    }
     /* and into our own peer object */
     if (NULL == pmix_globals.mypeer->nptr->nspace) {
-        pmix_globals.mypeer->nptr->nspace = strdup(proc->nspace);
+        pmix_globals.mypeer->nptr->nspace = strdup(pmix_globals.myid.nspace);
     }
     /* setup a rank_info object for us */
     pmix_globals.mypeer->info = PMIX_NEW(pmix_rank_info_t);
@@ -402,8 +550,40 @@ PMIX_EXPORT int PMIx_tool_init(pmix_proc_t *proc,
         PMIX_RELEASE_THREAD(&pmix_global_lock);
         return PMIX_ERR_NOMEM;
     }
-    pmix_globals.mypeer->info->pname.nspace = strdup(proc->nspace);
-    pmix_globals.mypeer->info->pname.rank = proc->rank;
+    pmix_globals.mypeer->info->pname.nspace = strdup(pmix_globals.myid.nspace);
+    pmix_globals.mypeer->info->pname.rank = pmix_globals.myid.rank;
+
+    /* if we are acting as a client, then send a request for our
+     * job info - we do this as a non-blocking
+     * transaction because some systems cannot handle very large
+     * blocking operations and error out if we try them. */
+    if (PMIX_PROC_IS_CLIENT(pmix_globals.mypeer)) {
+         req = PMIX_NEW(pmix_buffer_t);
+         PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver,
+                          req, &cmd, 1, PMIX_COMMAND);
+         if (PMIX_SUCCESS != rc) {
+            PMIX_ERROR_LOG(rc);
+            PMIX_RELEASE(req);
+            PMIX_RELEASE_THREAD(&pmix_global_lock);
+            return rc;
+        }
+        /* send to the server */
+        PMIX_CONSTRUCT(&cb, pmix_cb_t);
+        PMIX_PTL_SEND_RECV(rc, pmix_client_globals.myserver,
+                           req, job_data, (void*)&cb);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_RELEASE_THREAD(&pmix_global_lock);
+            return rc;
+        }
+        /* wait for the data to return */
+        PMIX_WAIT_THREAD(&cb.lock);
+        rc = cb.status;
+        PMIX_DESTRUCT(&cb);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_RELEASE_THREAD(&pmix_global_lock);
+            return rc;
+        }
+    }
 
     /* setup IOF */
     PMIX_IOF_SINK_DEFINE(&pmix_client_globals.iof_stdout, &pmix_globals.myid,
@@ -460,9 +640,9 @@ PMIX_EXPORT int PMIx_tool_init(pmix_proc_t *proc,
                 PMIX_IOF_READ_ACTIVATE(&stdinev);
             }
         } else {
-            /* if we are not looking at a tty, just setup a read event
-             * and activate it
-             */
+                /* if we are not looking at a tty, just setup a read event
+                 * and activate it
+                 */
             PMIX_CONSTRUCT(&stdinev, pmix_iof_read_event_t);
             stdinev.fd = fd;
             stdinev.always_readable = pmix_iof_fd_always_ready(fd);
@@ -483,314 +663,332 @@ PMIX_EXPORT int PMIx_tool_init(pmix_proc_t *proc,
     /* increment our init reference counter */
     pmix_globals.init_cntr++;
 
+    if (!PMIX_PROC_IS_CLIENT(pmix_globals.mypeer)) {
+        /* now finish the initialization by filling our local
+         * datastore with typical job-related info. No point
+         * in having the server generate these as we are
+         * obviously a singleton, and so the values are well-known */
+        (void)strncpy(wildcard.nspace, pmix_globals.myid.nspace, PMIX_MAX_NSLEN);
+        wildcard.rank = pmix_globals.myid.rank;
 
-    /* now finish the initialization by filling our local
-     * datastore with typical job-related info. No point
-     * in having the server generate these as we are
-     * obviously a singleton, and so the values are well-known */
-    (void)strncpy(wildcard.nspace, pmix_globals.myid.nspace, PMIX_MAX_NSLEN);
-    wildcard.rank = pmix_globals.myid.rank;
+        /* the jobid is just our nspace */
+        kptr = PMIX_NEW(pmix_kval_t);
+        kptr->key = strdup(PMIX_JOBID);
+        PMIX_VALUE_CREATE(kptr->value, 1);
+        kptr->value->type = PMIX_STRING;
+        kptr->value->data.string = strdup(pmix_globals.myid.nspace);
+        PMIX_GDS_STORE_KV(rc, pmix_globals.mypeer,
+                          &wildcard,
+                          PMIX_INTERNAL, kptr);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_ERROR_LOG(rc);
+            PMIX_RELEASE_THREAD(&pmix_global_lock);
+            return rc;
+        }
+        PMIX_RELEASE(kptr); // maintain accounting
 
-    /* the jobid is just our nspace */
-    kptr = PMIX_NEW(pmix_kval_t);
-    kptr->key = strdup(PMIX_JOBID);
-    PMIX_VALUE_CREATE(kptr->value, 1);
-    kptr->value->type = PMIX_STRING;
-    kptr->value->data.string = strdup(pmix_globals.myid.nspace);
-    PMIX_GDS_STORE_KV(rc, pmix_globals.mypeer,
-                      &wildcard,
-                      PMIX_INTERNAL, kptr);
-    if (PMIX_SUCCESS != rc) {
-        PMIX_ERROR_LOG(rc);
-        PMIX_RELEASE_THREAD(&pmix_global_lock);
-        return rc;
+        /* our rank */
+        kptr = PMIX_NEW(pmix_kval_t);
+        kptr->key = strdup(PMIX_RANK);
+        PMIX_VALUE_CREATE(kptr->value, 1);
+        kptr->value->type = PMIX_INT;
+        kptr->value->data.integer = 0;
+        PMIX_GDS_STORE_KV(rc, pmix_globals.mypeer,
+                          &pmix_globals.myid,
+                          PMIX_INTERNAL, kptr);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_ERROR_LOG(rc);
+            PMIX_RELEASE_THREAD(&pmix_global_lock);
+            return rc;
+        }
+        PMIX_RELEASE(kptr); // maintain accounting
+
+        /* nproc offset */
+        kptr = PMIX_NEW(pmix_kval_t);
+        kptr->key = strdup(PMIX_NPROC_OFFSET);
+        PMIX_VALUE_CREATE(kptr->value, 1);
+        kptr->value->type = PMIX_UINT32;
+        kptr->value->data.uint32 = 0;
+        PMIX_GDS_STORE_KV(rc, pmix_globals.mypeer,
+                          &wildcard,
+                          PMIX_INTERNAL, kptr);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_ERROR_LOG(rc);
+            PMIX_RELEASE_THREAD(&pmix_global_lock);
+            return rc;
+        }
+        PMIX_RELEASE(kptr); // maintain accounting
+
+        /* node size */
+        kptr = PMIX_NEW(pmix_kval_t);
+        kptr->key = strdup(PMIX_NODE_SIZE);
+        PMIX_VALUE_CREATE(kptr->value, 1);
+        kptr->value->type = PMIX_UINT32;
+        kptr->value->data.uint32 = 1;
+        PMIX_GDS_STORE_KV(rc, pmix_globals.mypeer,
+                          &wildcard,
+                          PMIX_INTERNAL, kptr);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_ERROR_LOG(rc);
+            PMIX_RELEASE_THREAD(&pmix_global_lock);
+            return rc;
+        }
+        PMIX_RELEASE(kptr); // maintain accounting
+
+        /* local peers */
+        kptr = PMIX_NEW(pmix_kval_t);
+        kptr->key = strdup(PMIX_LOCAL_PEERS);
+        PMIX_VALUE_CREATE(kptr->value, 1);
+        kptr->value->type = PMIX_STRING;
+        kptr->value->data.string = strdup("0");
+        PMIX_GDS_STORE_KV(rc, pmix_globals.mypeer,
+                          &wildcard,
+                          PMIX_INTERNAL, kptr);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_ERROR_LOG(rc);
+            PMIX_RELEASE_THREAD(&pmix_global_lock);
+            return rc;
+        }
+        PMIX_RELEASE(kptr); // maintain accounting
+
+        /* local leader */
+        kptr = PMIX_NEW(pmix_kval_t);
+        kptr->key = strdup(PMIX_LOCALLDR);
+        PMIX_VALUE_CREATE(kptr->value, 1);
+        kptr->value->type = PMIX_UINT32;
+        kptr->value->data.uint32 = 0;
+        PMIX_GDS_STORE_KV(rc, pmix_globals.mypeer,
+                          &wildcard,
+                          PMIX_INTERNAL, kptr);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_ERROR_LOG(rc);
+            PMIX_RELEASE_THREAD(&pmix_global_lock);
+            return rc;
+        }
+        PMIX_RELEASE(kptr); // maintain accounting
+
+        /* universe size */
+        kptr = PMIX_NEW(pmix_kval_t);
+        kptr->key = strdup(PMIX_UNIV_SIZE);
+        PMIX_VALUE_CREATE(kptr->value, 1);
+        kptr->value->type = PMIX_UINT32;
+        kptr->value->data.uint32 = 1;
+        PMIX_GDS_STORE_KV(rc, pmix_globals.mypeer,
+                          &wildcard,
+                          PMIX_INTERNAL, kptr);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_ERROR_LOG(rc);
+            PMIX_RELEASE_THREAD(&pmix_global_lock);
+            return rc;
+        }
+        PMIX_RELEASE(kptr); // maintain accounting
+
+        /* job size - we are our very own job, so we have no peers */
+        kptr = PMIX_NEW(pmix_kval_t);
+        kptr->key = strdup(PMIX_JOB_SIZE);
+        PMIX_VALUE_CREATE(kptr->value, 1);
+        kptr->value->type = PMIX_UINT32;
+        kptr->value->data.uint32 = 1;
+        PMIX_GDS_STORE_KV(rc, pmix_globals.mypeer,
+                          &wildcard,
+                          PMIX_INTERNAL, kptr);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_ERROR_LOG(rc);
+            PMIX_RELEASE_THREAD(&pmix_global_lock);
+            return rc;
+        }
+        PMIX_RELEASE(kptr); // maintain accounting
+
+        /* local size - only us in our job */
+        kptr = PMIX_NEW(pmix_kval_t);
+        kptr->key = strdup(PMIX_LOCAL_SIZE);
+        PMIX_VALUE_CREATE(kptr->value, 1);
+        kptr->value->type = PMIX_UINT32;
+        kptr->value->data.uint32 = 1;
+        PMIX_GDS_STORE_KV(rc, pmix_globals.mypeer,
+                          &wildcard,
+                          PMIX_INTERNAL, kptr);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_ERROR_LOG(rc);
+            PMIX_RELEASE_THREAD(&pmix_global_lock);
+            return rc;
+        }
+        PMIX_RELEASE(kptr); // maintain accounting
+
+        /* max procs - since we are a self-started tool, there is no
+         * allocation within which we can grow ourselves */
+        kptr = PMIX_NEW(pmix_kval_t);
+        kptr->key = strdup(PMIX_MAX_PROCS);
+        PMIX_VALUE_CREATE(kptr->value, 1);
+        kptr->value->type = PMIX_UINT32;
+        kptr->value->data.uint32 = 1;
+        PMIX_GDS_STORE_KV(rc, pmix_globals.mypeer,
+                          &wildcard,
+                          PMIX_INTERNAL, kptr);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_ERROR_LOG(rc);
+            PMIX_RELEASE_THREAD(&pmix_global_lock);
+            return rc;
+        }
+        PMIX_RELEASE(kptr); // maintain accounting
+
+        /* app number */
+        kptr = PMIX_NEW(pmix_kval_t);
+        kptr->key = strdup(PMIX_APPNUM);
+        PMIX_VALUE_CREATE(kptr->value, 1);
+        kptr->value->type = PMIX_UINT32;
+        kptr->value->data.uint32 = 0;
+        PMIX_GDS_STORE_KV(rc, pmix_globals.mypeer,
+                          &pmix_globals.myid,
+                          PMIX_INTERNAL, kptr);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_ERROR_LOG(rc);
+            PMIX_RELEASE_THREAD(&pmix_global_lock);
+            return rc;
+        }
+        PMIX_RELEASE(kptr); // maintain accounting
+
+        /* app leader */
+        kptr = PMIX_NEW(pmix_kval_t);
+        kptr->key = strdup(PMIX_APPLDR);
+        PMIX_VALUE_CREATE(kptr->value, 1);
+        kptr->value->type = PMIX_UINT32;
+        kptr->value->data.uint32 = 0;
+        PMIX_GDS_STORE_KV(rc, pmix_globals.mypeer,
+                          &pmix_globals.myid,
+                          PMIX_INTERNAL, kptr);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_ERROR_LOG(rc);
+            PMIX_RELEASE_THREAD(&pmix_global_lock);
+            return rc;
+        }
+        PMIX_RELEASE(kptr); // maintain accounting
+
+        /* app rank */
+        kptr = PMIX_NEW(pmix_kval_t);
+        kptr->key = strdup(PMIX_APP_RANK);
+        PMIX_VALUE_CREATE(kptr->value, 1);
+        kptr->value->type = PMIX_UINT32;
+        kptr->value->data.uint32 = 0;
+        PMIX_GDS_STORE_KV(rc, pmix_globals.mypeer,
+                          &pmix_globals.myid,
+                          PMIX_INTERNAL, kptr);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_ERROR_LOG(rc);
+            PMIX_RELEASE_THREAD(&pmix_global_lock);
+            return rc;
+        }
+        PMIX_RELEASE(kptr); // maintain accounting
+
+        /* global rank */
+        kptr = PMIX_NEW(pmix_kval_t);
+        kptr->key = strdup(PMIX_GLOBAL_RANK);
+        PMIX_VALUE_CREATE(kptr->value, 1);
+        kptr->value->type = PMIX_UINT32;
+        kptr->value->data.uint32 = 0;
+        PMIX_GDS_STORE_KV(rc, pmix_globals.mypeer,
+                          &pmix_globals.myid,
+                          PMIX_INTERNAL, kptr);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_ERROR_LOG(rc);
+            PMIX_RELEASE_THREAD(&pmix_global_lock);
+            return rc;
+        }
+        PMIX_RELEASE(kptr); // maintain accounting
+
+        /* local rank - we are alone in our job */
+        kptr = PMIX_NEW(pmix_kval_t);
+        kptr->key = strdup(PMIX_LOCAL_RANK);
+        PMIX_VALUE_CREATE(kptr->value, 1);
+        kptr->value->type = PMIX_UINT16;
+        kptr->value->data.uint32 = 0;
+        PMIX_GDS_STORE_KV(rc, pmix_globals.mypeer,
+                          &pmix_globals.myid,
+                          PMIX_INTERNAL, kptr);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_ERROR_LOG(rc);
+            PMIX_RELEASE_THREAD(&pmix_global_lock);
+            return rc;
+        }
+        PMIX_RELEASE(kptr); // maintain accounting
+
+        /* we cannot know the node rank as we don't know what
+         * other processes are executing on this node - so
+         * we'll add that info to the server-tool handshake
+         * and load it from there */
+
+        /* hostname */
+        gethostname(hostname, PMIX_MAX_NSLEN);
+        kptr = PMIX_NEW(pmix_kval_t);
+        kptr->key = strdup(PMIX_HOSTNAME);
+        PMIX_VALUE_CREATE(kptr->value, 1);
+        kptr->value->type = PMIX_STRING;
+        kptr->value->data.string = strdup(hostname);
+        PMIX_GDS_STORE_KV(rc, pmix_globals.mypeer,
+                          &pmix_globals.myid,
+                          PMIX_INTERNAL, kptr);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_ERROR_LOG(rc);
+            PMIX_RELEASE_THREAD(&pmix_global_lock);
+            return rc;
+        }
+        PMIX_RELEASE(kptr); // maintain accounting
+
+        /* we cannot know the RM's nodeid for this host, so
+         * we'll add that info to the server-tool handshake
+         * and load it from there */
+
+        /* the nodemap is simply our hostname as there is no
+         * regex to generate */
+        kptr = PMIX_NEW(pmix_kval_t);
+        kptr->key = strdup(PMIX_NODE_MAP);
+        PMIX_VALUE_CREATE(kptr->value, 1);
+        kptr->value->type = PMIX_STRING;
+        kptr->value->data.string = strdup(hostname);
+        PMIX_GDS_STORE_KV(rc, pmix_globals.mypeer,
+                          &wildcard,
+                          PMIX_INTERNAL, kptr);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_ERROR_LOG(rc);
+            PMIX_RELEASE_THREAD(&pmix_global_lock);
+            return rc;
+        }
+        PMIX_RELEASE(kptr); // maintain accounting
+
+        /* likewise, the proc map is just our rank as we are
+         * the only proc in this job */
+        kptr = PMIX_NEW(pmix_kval_t);
+        kptr->key = strdup(PMIX_PROC_MAP);
+        PMIX_VALUE_CREATE(kptr->value, 1);
+        kptr->value->type = PMIX_STRING;
+        kptr->value->data.string = strdup("0");
+        PMIX_GDS_STORE_KV(rc, pmix_globals.mypeer,
+                          &wildcard,
+                          PMIX_INTERNAL, kptr);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_ERROR_LOG(rc);
+            PMIX_RELEASE_THREAD(&pmix_global_lock);
+            return rc;
+        }
+        PMIX_RELEASE(kptr); // maintain accounting
     }
-    PMIX_RELEASE(kptr); // maintain accounting
 
-    /* our rank */
-    kptr = PMIX_NEW(pmix_kval_t);
-    kptr->key = strdup(PMIX_RANK);
-    PMIX_VALUE_CREATE(kptr->value, 1);
-    kptr->value->type = PMIX_INT;
-    kptr->value->data.integer = 0;
-    PMIX_GDS_STORE_KV(rc, pmix_globals.mypeer,
-                      &pmix_globals.myid,
-                      PMIX_INTERNAL, kptr);
-    if (PMIX_SUCCESS != rc) {
-        PMIX_ERROR_LOG(rc);
-        PMIX_RELEASE_THREAD(&pmix_global_lock);
-        return rc;
+    /* if we are acting as a server, then start listening */
+    if (PMIX_PROC_IS_LAUNCHER(pmix_globals.mypeer)) {
+        /* setup the wildcard recv for inbound messages from clients */
+        rcv = PMIX_NEW(pmix_ptl_posted_recv_t);
+        rcv->tag = UINT32_MAX;
+        rcv->cbfunc = pmix_server_message_handler;
+        /* add it to the end of the list of recvs */
+        pmix_list_append(&pmix_ptl_globals.posted_recvs, &rcv->super);
+
+        /* start listening for connections */
+        if (PMIX_SUCCESS != pmix_ptl_base_start_listening(info, ninfo)) {
+            pmix_show_help("help-pmix-server.txt", "listener-thread-start", true);
+            PMIX_RELEASE_THREAD(&pmix_global_lock);
+            return PMIX_ERR_INIT;
+        }
     }
-    PMIX_RELEASE(kptr); // maintain accounting
-
-    /* nproc offset */
-    kptr = PMIX_NEW(pmix_kval_t);
-    kptr->key = strdup(PMIX_NPROC_OFFSET);
-    PMIX_VALUE_CREATE(kptr->value, 1);
-    kptr->value->type = PMIX_UINT32;
-    kptr->value->data.uint32 = 0;
-    PMIX_GDS_STORE_KV(rc, pmix_globals.mypeer,
-                      &wildcard,
-                      PMIX_INTERNAL, kptr);
-    if (PMIX_SUCCESS != rc) {
-        PMIX_ERROR_LOG(rc);
-        PMIX_RELEASE_THREAD(&pmix_global_lock);
-        return rc;
-    }
-    PMIX_RELEASE(kptr); // maintain accounting
-
-    /* node size */
-    kptr = PMIX_NEW(pmix_kval_t);
-    kptr->key = strdup(PMIX_NODE_SIZE);
-    PMIX_VALUE_CREATE(kptr->value, 1);
-    kptr->value->type = PMIX_UINT32;
-    kptr->value->data.uint32 = 1;
-    PMIX_GDS_STORE_KV(rc, pmix_globals.mypeer,
-                      &wildcard,
-                      PMIX_INTERNAL, kptr);
-    if (PMIX_SUCCESS != rc) {
-        PMIX_ERROR_LOG(rc);
-        PMIX_RELEASE_THREAD(&pmix_global_lock);
-        return rc;
-    }
-    PMIX_RELEASE(kptr); // maintain accounting
-
-    /* local peers */
-    kptr = PMIX_NEW(pmix_kval_t);
-    kptr->key = strdup(PMIX_LOCAL_PEERS);
-    PMIX_VALUE_CREATE(kptr->value, 1);
-    kptr->value->type = PMIX_STRING;
-    kptr->value->data.string = strdup("0");
-    PMIX_GDS_STORE_KV(rc, pmix_globals.mypeer,
-                      &wildcard,
-                      PMIX_INTERNAL, kptr);
-    if (PMIX_SUCCESS != rc) {
-        PMIX_ERROR_LOG(rc);
-        PMIX_RELEASE_THREAD(&pmix_global_lock);
-        return rc;
-    }
-    PMIX_RELEASE(kptr); // maintain accounting
-
-    /* local leader */
-    kptr = PMIX_NEW(pmix_kval_t);
-    kptr->key = strdup(PMIX_LOCALLDR);
-    PMIX_VALUE_CREATE(kptr->value, 1);
-    kptr->value->type = PMIX_UINT32;
-    kptr->value->data.uint32 = 0;
-    PMIX_GDS_STORE_KV(rc, pmix_globals.mypeer,
-                      &wildcard,
-                      PMIX_INTERNAL, kptr);
-    if (PMIX_SUCCESS != rc) {
-        PMIX_ERROR_LOG(rc);
-        PMIX_RELEASE_THREAD(&pmix_global_lock);
-        return rc;
-    }
-    PMIX_RELEASE(kptr); // maintain accounting
-
-    /* universe size */
-    kptr = PMIX_NEW(pmix_kval_t);
-    kptr->key = strdup(PMIX_UNIV_SIZE);
-    PMIX_VALUE_CREATE(kptr->value, 1);
-    kptr->value->type = PMIX_UINT32;
-    kptr->value->data.uint32 = 1;
-    PMIX_GDS_STORE_KV(rc, pmix_globals.mypeer,
-                      &wildcard,
-                      PMIX_INTERNAL, kptr);
-    if (PMIX_SUCCESS != rc) {
-        PMIX_ERROR_LOG(rc);
-        PMIX_RELEASE_THREAD(&pmix_global_lock);
-        return rc;
-    }
-    PMIX_RELEASE(kptr); // maintain accounting
-
-    /* job size - we are our very own job, so we have no peers */
-    kptr = PMIX_NEW(pmix_kval_t);
-    kptr->key = strdup(PMIX_JOB_SIZE);
-    PMIX_VALUE_CREATE(kptr->value, 1);
-    kptr->value->type = PMIX_UINT32;
-    kptr->value->data.uint32 = 1;
-    PMIX_GDS_STORE_KV(rc, pmix_globals.mypeer,
-                      &wildcard,
-                      PMIX_INTERNAL, kptr);
-    if (PMIX_SUCCESS != rc) {
-        PMIX_ERROR_LOG(rc);
-        PMIX_RELEASE_THREAD(&pmix_global_lock);
-        return rc;
-    }
-    PMIX_RELEASE(kptr); // maintain accounting
-
-    /* local size - only us in our job */
-    kptr = PMIX_NEW(pmix_kval_t);
-    kptr->key = strdup(PMIX_LOCAL_SIZE);
-    PMIX_VALUE_CREATE(kptr->value, 1);
-    kptr->value->type = PMIX_UINT32;
-    kptr->value->data.uint32 = 1;
-    PMIX_GDS_STORE_KV(rc, pmix_globals.mypeer,
-                      &wildcard,
-                      PMIX_INTERNAL, kptr);
-    if (PMIX_SUCCESS != rc) {
-        PMIX_ERROR_LOG(rc);
-        PMIX_RELEASE_THREAD(&pmix_global_lock);
-        return rc;
-    }
-    PMIX_RELEASE(kptr); // maintain accounting
-
-    /* max procs - since we are a self-started tool, there is no
-     * allocation within which we can grow ourselves */
-    kptr = PMIX_NEW(pmix_kval_t);
-    kptr->key = strdup(PMIX_MAX_PROCS);
-    PMIX_VALUE_CREATE(kptr->value, 1);
-    kptr->value->type = PMIX_UINT32;
-    kptr->value->data.uint32 = 1;
-    PMIX_GDS_STORE_KV(rc, pmix_globals.mypeer,
-                      &wildcard,
-                      PMIX_INTERNAL, kptr);
-    if (PMIX_SUCCESS != rc) {
-        PMIX_ERROR_LOG(rc);
-        PMIX_RELEASE_THREAD(&pmix_global_lock);
-        return rc;
-    }
-    PMIX_RELEASE(kptr); // maintain accounting
-
-    /* app number */
-    kptr = PMIX_NEW(pmix_kval_t);
-    kptr->key = strdup(PMIX_APPNUM);
-    PMIX_VALUE_CREATE(kptr->value, 1);
-    kptr->value->type = PMIX_UINT32;
-    kptr->value->data.uint32 = 0;
-    PMIX_GDS_STORE_KV(rc, pmix_globals.mypeer,
-                      &pmix_globals.myid,
-                      PMIX_INTERNAL, kptr);
-    if (PMIX_SUCCESS != rc) {
-        PMIX_ERROR_LOG(rc);
-        PMIX_RELEASE_THREAD(&pmix_global_lock);
-        return rc;
-    }
-    PMIX_RELEASE(kptr); // maintain accounting
-
-    /* app leader */
-    kptr = PMIX_NEW(pmix_kval_t);
-    kptr->key = strdup(PMIX_APPLDR);
-    PMIX_VALUE_CREATE(kptr->value, 1);
-    kptr->value->type = PMIX_UINT32;
-    kptr->value->data.uint32 = 0;
-    PMIX_GDS_STORE_KV(rc, pmix_globals.mypeer,
-                      &pmix_globals.myid,
-                      PMIX_INTERNAL, kptr);
-    if (PMIX_SUCCESS != rc) {
-        PMIX_ERROR_LOG(rc);
-        PMIX_RELEASE_THREAD(&pmix_global_lock);
-        return rc;
-    }
-    PMIX_RELEASE(kptr); // maintain accounting
-
-    /* app rank */
-    kptr = PMIX_NEW(pmix_kval_t);
-    kptr->key = strdup(PMIX_APP_RANK);
-    PMIX_VALUE_CREATE(kptr->value, 1);
-    kptr->value->type = PMIX_UINT32;
-    kptr->value->data.uint32 = 0;
-    PMIX_GDS_STORE_KV(rc, pmix_globals.mypeer,
-                      &pmix_globals.myid,
-                      PMIX_INTERNAL, kptr);
-    if (PMIX_SUCCESS != rc) {
-        PMIX_ERROR_LOG(rc);
-        PMIX_RELEASE_THREAD(&pmix_global_lock);
-        return rc;
-    }
-    PMIX_RELEASE(kptr); // maintain accounting
-
-    /* global rank */
-    kptr = PMIX_NEW(pmix_kval_t);
-    kptr->key = strdup(PMIX_GLOBAL_RANK);
-    PMIX_VALUE_CREATE(kptr->value, 1);
-    kptr->value->type = PMIX_UINT32;
-    kptr->value->data.uint32 = 0;
-    PMIX_GDS_STORE_KV(rc, pmix_globals.mypeer,
-                      &pmix_globals.myid,
-                      PMIX_INTERNAL, kptr);
-    if (PMIX_SUCCESS != rc) {
-        PMIX_ERROR_LOG(rc);
-        PMIX_RELEASE_THREAD(&pmix_global_lock);
-        return rc;
-    }
-    PMIX_RELEASE(kptr); // maintain accounting
-
-    /* local rank - we are alone in our job */
-    kptr = PMIX_NEW(pmix_kval_t);
-    kptr->key = strdup(PMIX_LOCAL_RANK);
-    PMIX_VALUE_CREATE(kptr->value, 1);
-    kptr->value->type = PMIX_UINT32;
-    kptr->value->data.uint32 = 0;
-    PMIX_GDS_STORE_KV(rc, pmix_globals.mypeer,
-                      &pmix_globals.myid,
-                      PMIX_INTERNAL, kptr);
-    if (PMIX_SUCCESS != rc) {
-        PMIX_ERROR_LOG(rc);
-        PMIX_RELEASE_THREAD(&pmix_global_lock);
-        return rc;
-    }
-    PMIX_RELEASE(kptr); // maintain accounting
-
-    /* we cannot know the node rank as we don't know what
-     * other processes are executing on this node - so
-     * we'll add that info to the server-tool handshake
-     * and load it from there */
-
-    /* hostname */
-     gethostname(hostname, PMIX_MAX_NSLEN);
-     kptr = PMIX_NEW(pmix_kval_t);
-     kptr->key = strdup(PMIX_HOSTNAME);
-     PMIX_VALUE_CREATE(kptr->value, 1);
-     kptr->value->type = PMIX_STRING;
-     kptr->value->data.string = strdup(hostname);
-     PMIX_GDS_STORE_KV(rc, pmix_globals.mypeer,
-                       &pmix_globals.myid,
-                       PMIX_INTERNAL, kptr);
-     if (PMIX_SUCCESS != rc) {
-        PMIX_ERROR_LOG(rc);
-        PMIX_RELEASE_THREAD(&pmix_global_lock);
-        return rc;
-    }
-    PMIX_RELEASE(kptr); // maintain accounting
-
-    /* we cannot know the RM's nodeid for this host, so
-     * we'll add that info to the server-tool handshake
-     * and load it from there */
-
-    /* the nodemap is simply our hostname as there is no
-     * regex to generate */
-     kptr = PMIX_NEW(pmix_kval_t);
-     kptr->key = strdup(PMIX_NODE_MAP);
-     PMIX_VALUE_CREATE(kptr->value, 1);
-     kptr->value->type = PMIX_STRING;
-     kptr->value->data.string = strdup(hostname);
-     PMIX_GDS_STORE_KV(rc, pmix_globals.mypeer,
-                       &wildcard,
-                       PMIX_INTERNAL, kptr);
-     if (PMIX_SUCCESS != rc) {
-        PMIX_ERROR_LOG(rc);
-        PMIX_RELEASE_THREAD(&pmix_global_lock);
-        return rc;
-    }
-    PMIX_RELEASE(kptr); // maintain accounting
-
-    /* likewise, the proc map is just our rank as we are
-     * the only proc in this job */
-    kptr = PMIX_NEW(pmix_kval_t);
-    kptr->key = strdup(PMIX_PROC_MAP);
-    PMIX_VALUE_CREATE(kptr->value, 1);
-    kptr->value->type = PMIX_STRING;
-    kptr->value->data.string = strdup("0");
-    PMIX_GDS_STORE_KV(rc, pmix_globals.mypeer,
-                      &wildcard,
-                      PMIX_INTERNAL, kptr);
-    if (PMIX_SUCCESS != rc) {
-        PMIX_ERROR_LOG(rc);
-        PMIX_RELEASE_THREAD(&pmix_global_lock);
-        return rc;
-    }
-    PMIX_RELEASE(kptr); // maintain accounting
 
     PMIX_RELEASE_THREAD(&pmix_global_lock);
     return rc;
@@ -841,6 +1039,7 @@ PMIX_EXPORT pmix_status_t PMIx_tool_finalize(void)
     struct timeval tv = {2, 0};
     int n;
     pmix_peer_t *peer;
+    pmix_setup_caddy_t *cd;
 
     PMIX_ACQUIRE_THREAD(&pmix_global_lock);
     if (1 != pmix_globals.init_cntr) {
@@ -879,7 +1078,7 @@ PMIX_EXPORT pmix_status_t PMIx_tool_finalize(void)
 
 
     pmix_output_verbose(2, pmix_globals.debug_output,
-                         "pmix:tool sending finalize sync to server");
+                        "pmix:tool sending finalize sync to server");
 
     /* setup a timer to protect ourselves should the server be unable
      * to answer for some reason */
@@ -905,7 +1104,7 @@ PMIX_EXPORT pmix_status_t PMIx_tool_finalize(void)
         pmix_event_del(&tev.ev);
     }
     pmix_output_verbose(2, pmix_globals.debug_output,
-                         "pmix:tool finalize sync received");
+                        "pmix:tool finalize sync received");
 
     if (!pmix_globals.external_evbase) {
         /* stop the progress thread, but leave the event base
@@ -923,8 +1122,106 @@ PMIX_EXPORT pmix_status_t PMIx_tool_finalize(void)
         }
     }
 
+    if (PMIX_PROC_IS_LAUNCHER(pmix_globals.mypeer)) {
+        pmix_ptl_base_stop_listening();
+
+        /* cleanout any IOF */
+        for (n=0; n < PMIX_IOF_HOTEL_SIZE; n++) {
+            pmix_hotel_checkout_and_return_occupant(&pmix_server_globals.iof, n, (void**)&cd);
+            if (NULL != cd) {
+                PMIX_RELEASE(cd);
+            }
+        }
+        PMIX_DESTRUCT(&pmix_server_globals.iof);
+        for (n=0; n < pmix_server_globals.clients.size; n++) {
+            if (NULL != (peer = (pmix_peer_t*)pmix_pointer_array_get_item(&pmix_server_globals.clients, n))) {
+                PMIX_RELEASE(peer);
+            }
+        }
+        PMIX_DESTRUCT(&pmix_server_globals.clients);
+        PMIX_LIST_DESTRUCT(&pmix_server_globals.collectives);
+        PMIX_LIST_DESTRUCT(&pmix_server_globals.remote_pnd);
+        PMIX_LIST_DESTRUCT(&pmix_server_globals.local_reqs);
+        PMIX_LIST_DESTRUCT(&pmix_server_globals.gdata);
+        PMIX_LIST_DESTRUCT(&pmix_server_globals.events);
+        PMIX_LIST_DESTRUCT(&pmix_server_globals.nspaces);
+    }
+
     /* shutdown services */
     pmix_rte_finalize();
 
     return PMIX_SUCCESS;
+}
+
+pmix_status_t PMIx_tool_connect_to_server(pmix_proc_t *proc,
+                                          pmix_info_t info[], size_t ninfo)
+{
+    pmix_buffer_t *msg;
+    pmix_cmd_t cmd = PMIX_FINALIZE_CMD;
+    pmix_status_t rc;
+    pmix_tool_timeout_t tev;
+    struct timeval tv = {2, 0};
+
+    PMIX_ACQUIRE_THREAD(&pmix_global_lock);
+    if (pmix_globals.init_cntr <= 0) {
+        PMIX_RELEASE_THREAD(&pmix_global_lock);
+        return PMIX_ERR_INIT;
+    }
+    PMIX_RELEASE_THREAD(&pmix_global_lock);
+
+    /* check for bozo error - we do this
+     * prior to breaking any existing connection to avoid
+     * becoming stranded due to an incorrect function call */
+    if (NULL == info || 0 == ninfo) {
+        pmix_show_help("help-pmix-runtime.txt", "tool:no-server", true);
+        return PMIX_ERR_BAD_PARAM;
+    }
+
+    /* break any existing connection */
+    if (pmix_globals.connected) {
+        /* gracefully terminate this connection */
+        msg = PMIX_NEW(pmix_buffer_t);
+        /* pack the cmd */
+        PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver,
+                         msg, &cmd, 1, PMIX_COMMAND);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_ERROR_LOG(rc);
+            PMIX_RELEASE(msg);
+            return rc;
+        }
+
+
+        pmix_output_verbose(2, pmix_globals.debug_output,
+                            "pmix:tool:reconnect sending finalize sync to server");
+
+        /* setup a timer to protect ourselves should the server be unable
+         * to answer for some reason */
+        PMIX_CONSTRUCT_LOCK(&tev.lock);
+        pmix_event_assign(&tev.ev, pmix_globals.evbase, -1, 0,
+                          fin_timeout, &tev);
+        tev.active = true;
+        PMIX_POST_OBJECT(&tev);
+        pmix_event_add(&tev.ev, &tv);
+        PMIX_PTL_SEND_RECV(rc, pmix_client_globals.myserver, msg,
+                           finwait_cbfunc, (void*)&tev);
+        if (PMIX_SUCCESS != rc) {
+            if (tev.active) {
+                pmix_event_del(&tev.ev);
+            }
+            return rc;
+        }
+
+        /* wait for the ack to return */
+        PMIX_WAIT_THREAD(&tev.lock);
+        PMIX_DESTRUCT_LOCK(&tev.lock);
+        if (tev.active) {
+            pmix_event_del(&tev.ev);
+        }
+        pmix_output_verbose(2, pmix_globals.debug_output,
+                            "pmix:tool:reconnect finalize sync received");
+    }
+
+    /* now ask the ptl to establish connection to the new server */
+    rc = pmix_ptl_base_connect_to_peer((struct pmix_peer_t*)pmix_client_globals.myserver, info, ninfo);
+    return rc;
 }

--- a/opal/mca/pmix/pmix3x/pmix/src/util/error.c
+++ b/opal/mca/pmix/pmix3x/pmix/src/util/error.c
@@ -38,143 +38,212 @@
 PMIX_EXPORT const char* PMIx_Error_string(pmix_status_t errnum)
 {
     switch(errnum) {
-    case PMIX_ERR_UNPACK_READ_PAST_END_OF_BUFFER:
-        return "UNPACK-PAST-END";
-    case PMIX_ERR_LOST_CONNECTION_TO_SERVER:
-        return "LOST_CONNECTION_TO_SERVER";
-    case PMIX_ERR_NOT_SUPPORTED:
-        return "NOT-SUPPORTED";
-    case PMIX_ERR_NOT_FOUND:
-        return "NOT-FOUND";
-    case PMIX_ERR_SERVER_NOT_AVAIL:
-        return "SERVER-NOT-AVAIL";
-    case PMIX_ERR_INVALID_NAMESPACE:
-        return "INVALID-NAMESPACE";
-    case PMIX_ERR_INVALID_SIZE:
-        return "INVALID-SIZE";
-    case PMIX_ERR_INVALID_KEYVALP:
-        return "INVALID-KEYVAL";
-    case PMIX_ERR_INVALID_NUM_PARSED:
-        return "INVALID-NUM-PARSED";
-    case PMIX_ERR_TAKE_NEXT_OPTION:
-        return "TAKE-NEXT-OPTION";
 
-    case PMIX_ERR_INVALID_ARGS:
-        return "INVALID-ARGS";
-    case PMIX_ERR_INVALID_NUM_ARGS:
-        return "INVALID-NUM-ARGS";
-    case PMIX_ERR_INVALID_LENGTH:
-        return "INVALID-LENGTH";
-    case PMIX_ERR_INVALID_VAL_LENGTH:
-        return "INVALID-VAL-LENGTH";
-    case PMIX_ERR_INVALID_VAL:
-        return "INVALID-VAL";
-    case PMIX_ERR_INVALID_KEY_LENGTH:
-        return "INVALID-KEY-LENGTH";
-    case PMIX_ERR_INVALID_KEY:
-        return "INVALID-KEY";
-    case PMIX_ERR_INVALID_ARG:
-        return "INVALID-ARG";
-    case PMIX_ERR_NOMEM:
-        return "NO-MEM";
-    case PMIX_ERR_INIT:
-        return "INIT";
-
-    case PMIX_ERR_DATA_VALUE_NOT_FOUND:
-        return "DATA-VALUE-NOT-FOUND";
-    case PMIX_ERR_OUT_OF_RESOURCE:
-        return "OUT-OF-RESOURCE";
-    case PMIX_ERR_BAD_PARAM:
-        return "BAD-PARAM";
-    case PMIX_ERR_IN_ERRNO:
-        return "ERR-IN-ERRNO";
-    case PMIX_ERR_UNREACH:
-        return "UNREACHABLE";
-    case PMIX_ERR_TIMEOUT:
-        return "TIMEOUT";
-    case PMIX_ERR_NO_PERMISSIONS:
-        return "NO-PERMISSIONS";
-    case PMIX_ERR_PACK_MISMATCH:
-        return "PACK-MISMATCH";
-    case PMIX_ERR_PACK_FAILURE:
-        return "PACK-FAILURE";
-
-    case PMIX_ERR_UNPACK_FAILURE:
-        return "UNPACK-FAILURE";
-    case PMIX_ERR_UNPACK_INADEQUATE_SPACE:
-        return "UNPACK-INADEQUATE-SPACE";
-    case PMIX_ERR_TYPE_MISMATCH:
-        return "TYPE-MISMATCH";
-    case PMIX_ERR_PROC_ENTRY_NOT_FOUND:
-        return "PROC-ENTRY-NOT-FOUND";
-    case PMIX_ERR_UNKNOWN_DATA_TYPE:
-        return "UNKNOWN-DATA-TYPE";
-    case PMIX_ERR_WOULD_BLOCK:
-        return "WOULD-BLOCK";
-    case PMIX_ERR_READY_FOR_HANDSHAKE:
-        return "READY-FOR-HANDSHAKE";
-    case PMIX_ERR_HANDSHAKE_FAILED:
-        return "HANDSHAKE-FAILED";
-    case PMIX_ERR_INVALID_CRED:
-        return "INVALID-CREDENTIAL";
-    case PMIX_EXISTS:
-        return "EXISTS";
-    case PMIX_ERR_SERVER_FAILED_REQUEST:
-        return "SERVER FAILED REQUEST";
-    case PMIX_ERR_PROC_MIGRATE:
-        return "PROC-MIGRATE";
-    case PMIX_ERR_PROC_CHECKPOINT:
-        return "PROC-CHECKPOINT-ERROR";
-    case PMIX_ERR_PROC_RESTART:
-        return "PROC_RESTART";
-    case PMIX_ERR_PROC_ABORTING:
-        return "PROC-ABORTING";
-    case PMIX_ERR_PROC_REQUESTED_ABORT:
-        return "PROC-ABORT-REQUESTED";
-    case PMIX_ERR_PROC_ABORTED:
-        return "PROC-ABORTED";
-    case PMIX_ERR_DEBUGGER_RELEASE:
-        return "DEBUGGER-RELEASE";
-    case PMIX_ERR_SILENT:
-        return "SILENT_ERROR";
+    case PMIX_SUCCESS:
+        return "SUCCESS";
     case PMIX_ERROR:
         return "ERROR";
+    case PMIX_ERR_SILENT:
+        return "SILENT_ERROR";
+
+
+    case PMIX_ERR_DEBUGGER_RELEASE:
+        return "DEBUGGER-RELEASE";
+
+
+    case PMIX_ERR_PROC_RESTART:
+        return "PROC_RESTART";
+    case PMIX_ERR_PROC_CHECKPOINT:
+        return "PROC-CHECKPOINT-ERROR";
+    case PMIX_ERR_PROC_MIGRATE:
+        return "PROC-MIGRATE";
+
+
+    case PMIX_ERR_PROC_ABORTED:
+        return "PROC-ABORTED";
+    case PMIX_ERR_PROC_REQUESTED_ABORT:
+        return "PROC-ABORT-REQUESTED";
+    case PMIX_ERR_PROC_ABORTING:
+        return "PROC-ABORTING";
+
+
+    case PMIX_ERR_SERVER_FAILED_REQUEST:
+        return "SERVER FAILED REQUEST";
+    case PMIX_EXISTS:
+        return "EXISTS";
+    case PMIX_ERR_INVALID_CRED:
+        return "INVALID-CREDENTIAL";
+    case PMIX_ERR_HANDSHAKE_FAILED:
+        return "HANDSHAKE-FAILED";
+    case PMIX_ERR_READY_FOR_HANDSHAKE:
+        return "READY-FOR-HANDSHAKE";
+    case PMIX_ERR_WOULD_BLOCK:
+        return "WOULD-BLOCK";
+    case PMIX_ERR_UNKNOWN_DATA_TYPE:
+        return "UNKNOWN-DATA-TYPE";
+    case PMIX_ERR_PROC_ENTRY_NOT_FOUND:
+        return "PROC-ENTRY-NOT-FOUND";
+    case PMIX_ERR_TYPE_MISMATCH:
+        return "TYPE-MISMATCH";
+    case PMIX_ERR_UNPACK_INADEQUATE_SPACE:
+        return "UNPACK-INADEQUATE-SPACE";
+    case PMIX_ERR_UNPACK_FAILURE:
+        return "UNPACK-FAILURE";
+    case PMIX_ERR_PACK_FAILURE:
+        return "PACK-FAILURE";
+    case PMIX_ERR_PACK_MISMATCH:
+        return "PACK-MISMATCH";
+    case PMIX_ERR_NO_PERMISSIONS:
+        return "NO-PERMISSIONS";
+    case PMIX_ERR_TIMEOUT:
+        return "TIMEOUT";
+    case PMIX_ERR_UNREACH:
+        return "UNREACHABLE";
+    case PMIX_ERR_IN_ERRNO:
+        return "ERR-IN-ERRNO";
+    case PMIX_ERR_BAD_PARAM:
+        return "BAD-PARAM";
+    case PMIX_ERR_RESOURCE_BUSY:
+        return "RESOURCE-BUSY";
+    case PMIX_ERR_OUT_OF_RESOURCE:
+        return "OUT-OF-RESOURCE";
+    case PMIX_ERR_DATA_VALUE_NOT_FOUND:
+        return "DATA-VALUE-NOT-FOUND";
+    case PMIX_ERR_INIT:
+        return "INIT";
+    case PMIX_ERR_NOMEM:
+        return "NO-MEM";
+    case PMIX_ERR_INVALID_ARG:
+        return "INVALID-ARG";
+    case PMIX_ERR_INVALID_KEY:
+        return "INVALID-KEY";
+    case PMIX_ERR_INVALID_KEY_LENGTH:
+        return "INVALID-KEY-LENGTH";
+    case PMIX_ERR_INVALID_VAL:
+        return "INVALID-VAL";
+    case PMIX_ERR_INVALID_VAL_LENGTH:
+        return "INVALID-VAL-LENGTH";
+    case PMIX_ERR_INVALID_LENGTH:
+        return "INVALID-LENGTH";
+    case PMIX_ERR_INVALID_NUM_ARGS:
+        return "INVALID-NUM-ARGS";
+    case PMIX_ERR_INVALID_ARGS:
+        return "INVALID-ARGS";
+    case PMIX_ERR_INVALID_NUM_PARSED:
+        return "INVALID-NUM-PARSED";
+    case PMIX_ERR_INVALID_KEYVALP:
+        return "INVALID-KEYVAL";
+    case PMIX_ERR_INVALID_SIZE:
+        return "INVALID-SIZE";
+    case PMIX_ERR_INVALID_NAMESPACE:
+        return "INVALID-NAMESPACE";
+    case PMIX_ERR_SERVER_NOT_AVAIL:
+        return "SERVER-NOT-AVAIL";
+    case PMIX_ERR_NOT_FOUND:
+        return "NOT-FOUND";
+    case PMIX_ERR_NOT_SUPPORTED:
+        return "NOT-SUPPORTED";
+    case PMIX_ERR_NOT_IMPLEMENTED:
+        return "NOT-IMPLEMENTED";
+    case PMIX_ERR_COMM_FAILURE:
+        return "COMM-FAILURE";
+    case PMIX_ERR_UNPACK_READ_PAST_END_OF_BUFFER:
+        return "UNPACK-PAST-END";
+    case PMIX_ERR_CONFLICTING_CLEANUP_DIRECTIVES:
+        return "PMIX CONFLICTING CLEANUP DIRECTIVES";
+
+
+    case PMIX_ERR_LOST_CONNECTION_TO_SERVER:
+        return "LOST_CONNECTION_TO_SERVER";
+    case PMIX_ERR_LOST_PEER_CONNECTION:
+        return "LOST-PEER-CONNECTION";
+    case PMIX_ERR_LOST_CONNECTION_TO_CLIENT:
+        return "LOST-CONNECTION-TO-CLIENT";
+
+
+    case PMIX_QUERY_PARTIAL_SUCCESS:
+        return "QUERY-PARTIAL-SUCCESS";
+
+
+    case PMIX_NOTIFY_ALLOC_COMPLETE:
+        return "PMIX ALLOC OPERATION COMPLETE";
+
+
+    case PMIX_JCTRL_CHECKPOINT:
+        return "PMIX JOB CONTROL CHECKPOINT";
+    case PMIX_JCTRL_CHECKPOINT_COMPLETE:
+        return "PMIX JOB CONTROL CHECKPOINT COMPLETE";
+    case PMIX_JCTRL_PREEMPT_ALERT:
+        return "PMIX PRE-EMPTION ALERT";
+
+
+    case PMIX_MONITOR_HEARTBEAT_ALERT:
+        return "PMIX HEARTBEAT ALERT";
+    case PMIX_MONITOR_FILE_ALERT:
+        return "PMIX FILE MONITOR ALERT";
+
+    case PMIX_ERR_EVENT_REGISTRATION:
+        return "EVENT-REGISTRATION";
+    case PMIX_ERR_JOB_TERMINATED:
+        return "PMIX_ERR_JOB_TERMINATED";
+    case PMIX_ERR_UPDATE_ENDPOINTS:
+        return "UPDATE-ENDPOINTS";
+    case PMIX_MODEL_DECLARED:
+        return "PMIX MODEL DECLARED";
+    case PMIX_GDS_ACTION_COMPLETE:
+        return "GDS-ACTION-COMPLETE";
+    case PMIX_PROC_HAS_CONNECTED:
+        return "PROC-HAS-CONNECTED";
+    case PMIX_CONNECT_REQUESTED:
+        return "CONNECT-REQUESTED";
+    case PMIX_LAUNCH_DIRECTIVE:
+        return "LAUNCH-DIRECTIVE";
+    case PMIX_LAUNCHER_READY:
+        return "LAUNCHER-READY";
+
+
+    case PMIX_ERR_NODE_DOWN:
+        return "NODE-DOWN";
+    case PMIX_ERR_NODE_OFFLINE:
+        return "NODE-OFFLINE";
+
+
+    case PMIX_EVENT_NO_ACTION_TAKEN:
+        return "EVENT-NO-ACTION-TAKEN";
+    case PMIX_EVENT_PARTIAL_ACTION_TAKEN:
+        return "EVENT-PARTIAL-ACTION-TAKEN";
+    case PMIX_EVENT_ACTION_DEFERRED:
+        return "EVENT-ACTION-DEFERRED";
+    case PMIX_EVENT_ACTION_COMPLETE:
+        return "EVENT-ACTION-COMPLETE";
+
+
     case PMIX_ERR_NOT_AVAILABLE:
         return "PMIX_ERR_NOT_AVAILABLE";
     case PMIX_ERR_FATAL:
         return "PMIX_ERR_FATAL";
     case PMIX_ERR_VALUE_OUT_OF_BOUNDS:
         return "PMIX_ERR_VALUE_OUT_OF_BOUNDS";
+    case PMIX_ERR_PERM:
+        return "PMIX_ERR_PERM";
+    case PMIX_ERR_OPERATION_IN_PROGRESS:
+        return "OPERATION-IN-PROGRESS";
     case PMIX_ERR_NETWORK_NOT_PARSEABLE:
         return "PMIX_ERR_NETWORK_NOT_PARSEABLE";
     case PMIX_ERR_FILE_OPEN_FAILURE:
         return "PMIX_ERR_FILE_OPEN_FAILURE";
     case PMIX_ERR_FILE_READ_FAILURE:
         return "PMIX_ERR_FILE_READ_FAILURE";
-    case PMIX_ERR_PERM:
-        return "PMIX_ERR_PERM";
-    case PMIX_ERR_JOB_TERMINATED:
-        return "PMIX_ERR_JOB_TERMINATED";
-    case PMIX_MAX_ERR_CONSTANT:
-        return "PMIX_ERR_WILDCARD";
-    case PMIX_NOTIFY_ALLOC_COMPLETE:
-        return "PMIX ALLOC OPERATION COMPLETE";
-    case PMIX_JCTRL_CHECKPOINT:
-        return "PMIX JOB CONTROL CHECKPOINT";
-    case PMIX_JCTRL_PREEMPT_ALERT:
-        return "PMIX PRE-EMPTION ALERT";
-    case PMIX_MONITOR_HEARTBEAT_ALERT:
-        return "PMIX HEARTBEAT ALERT";
-    case PMIX_MONITOR_FILE_ALERT:
-        return "PMIX FILE MONITOR ALERT";
-    case PMIX_MODEL_DECLARED:
-        return "PMIX MODEL DECLARED";
+    case PMIX_ERR_TAKE_NEXT_OPTION:
+        return "TAKE-NEXT-OPTION";
     case PMIX_ERR_TEMP_UNAVAILABLE:
         return "PMIX TEMPORARILY UNAVAILABLE";
-    case PMIX_ERR_CONFLICTING_CLEANUP_DIRECTIVES:
-        return "PMIX CONFLICTING CLEANUP DIRECTIVES";
-    case PMIX_SUCCESS:
-        return "SUCCESS";
+
+
+    case PMIX_MAX_ERR_CONSTANT:
+        return "PMIX_ERR_WILDCARD";
+
+
     default:
         return "ERROR STRING NOT FOUND";
     }

--- a/opal/mca/pmix/pmix3x/pmix3x.c
+++ b/opal/mca/pmix/pmix3x/pmix3x.c
@@ -896,7 +896,14 @@ void pmix3x_value_load(pmix_value_t *v,
             memcpy(&v->data.state, &kv->data.uint8, sizeof(uint8_t));
             break;
         case OPAL_PTR:
-            /* if someone returned a pointer, it must be to a list of
+            /* if the opal_value_t is passing a true pointer, then
+             * respect that request and pass it along */
+            if (0 == strcmp(kv->key, OPAL_PMIX_EVENT_RETURN_OBJECT)) {
+                v->type = PMIX_POINTER;
+                v->data.ptr = kv->data.ptr;
+                break;
+            }
+            /* otherwise, it must be to a list of
              * opal_value_t's that we need to convert to a pmix_data_array
              * of pmix_info_t structures */
             list = (opal_list_t*)kv->data.ptr;

--- a/opal/mca/pmix/pmix_types.h
+++ b/opal/mca/pmix/pmix_types.h
@@ -75,11 +75,14 @@ BEGIN_C_DECLS
 #define OPAL_PMIX_CONNECT_RETRY_DELAY           "pmix.tool.retry"       // (uint32_t) time in seconds between connection attempts
 #define OPAL_PMIX_TOOL_DO_NOT_CONNECT           "pmix.tool.nocon"       // (bool) the tool wants to use internal PMIx support, but does
                                                                         //        not want to connect to a PMIx server
+#define OPAL_PMIX_RECONNECT_SERVER              "pmix.cnct.recon"       // (bool) tool is requesting to change server connections
+#define OPAL_PMIX_LAUNCHER                      "pmix.tool.launcher"    // (bool) tool is a launcher and needs rendezvous files created
 
 
 /* identification attributes */
 #define OPAL_PMIX_USERID                        "pmix.euid"             // (uint32_t) effective user id
 #define OPAL_PMIX_GRPID                         "pmix.egid"             // (uint32_t) effective group id
+#define OPAL_PMIX_VERSION_INFO                  "pmix.version"          // (char*) PMIx version of contactor
 #define OPAL_PMIX_PROGRAMMING_MODEL             "pmix.pgm.model"        // (char*) programming model being initialized (e.g., "MPI" or "OpenMP")
 #define OPAL_PMIX_MODEL_LIBRARY_NAME            "pmix.mdl.name"         // (char*) programming model implementation ID (e.g., "OpenMPI" or "MPICH")
 #define OPAL_PMIX_MODEL_LIBRARY_VERSION         "pmix.mld.vrs"          // (char*) programming model version string (e.g., "2.1.1")
@@ -145,6 +148,7 @@ BEGIN_C_DECLS
 #define OPAL_PMIX_PROC_URI                      "opal.puri"             // (char*) URI containing contact info for proc - NOTE: this is published by procs and
                                                                         //            thus cannot be prefixed with "pmix"
 #define OPAL_PMIX_LOCALITY                      "pmix.loc"              // (uint16_t) relative locality of two procs
+#define OPAL_PMIX_APPNAME                       "pmix.appname"          // (char*) argv[0] of the application
 
 
 /* Memory info */

--- a/opal/runtime/opal_init.c
+++ b/opal/runtime/opal_init.c
@@ -303,6 +303,9 @@ opal_err2str(int errnum, const char **errmsg)
     case OPAL_PMIX_LAUNCH_DIRECTIVE:
         retval = "Launch directive";
         break;
+    case OPAL_PMIX_LAUNCHER_READY:
+        retval = "Launcher ready";
+        break;
     default:
         retval = "UNRECOGNIZED";
     }

--- a/orte/mca/iof/hnp/iof_hnp_read.c
+++ b/orte/mca/iof/hnp/iof_hnp_read.c
@@ -308,9 +308,9 @@ void orte_iof_hnp_read_local_handler(int fd, short event, void *cbdata)
         return;
     }
 
-    if (proct->copy) {
+    if (1) {
         if (NULL != proct->subscribers) {
-            if (!exclusive) {
+            if (1) {
                 /* output this to our local output */
                 if (ORTE_IOF_STDOUT & rev->tag || orte_xml_output) {
                     orte_iof_base_write_output(&proct->name, rev->tag, data, numbytes, orte_iof_base.iof_write_stdout->wev);

--- a/orte/mca/iof/hnp/iof_hnp_receive.c
+++ b/orte/mca/iof/hnp/iof_hnp_receive.c
@@ -267,12 +267,12 @@ void orte_iof_hnp_recv(int status, orte_process_name_t* sender,
         }
     }
     /* if the user doesn't want a copy written to the screen, then we are done */
-    if (!proct->copy) {
+    if (0) {
         return;
     }
 
     /* output this to our local output unless one of the sinks was exclusive */
-    if (!exclusive) {
+    if (1) {
         if (ORTE_IOF_STDOUT & stream || orte_xml_output) {
             orte_iof_base_write_output(&origin, stream, data, numbytes, orte_iof_base.iof_write_stdout->wev);
         } else {

--- a/orte/mca/odls/base/odls_base_default_fns.c
+++ b/orte/mca/odls/base/odls_base_default_fns.c
@@ -743,7 +743,7 @@ int orte_odls_base_default_construct_child_list(opal_buffer_t *buffer,
 
     /* register this job with the PMIx server - need to wait until after we
      * have computed the #local_procs before calling the function */
-    if (ORTE_SUCCESS != (rc = orte_pmix_server_register_nspace(jdata, false))) {
+    if (ORTE_SUCCESS != (rc = orte_pmix_server_register_nspace(jdata))) {
         ORTE_ERROR_LOG(rc);
         goto REPORT_ERROR;
     }

--- a/orte/mca/rmaps/base/rmaps_base_support_fns.c
+++ b/orte/mca/rmaps/base/rmaps_base_support_fns.c
@@ -217,6 +217,10 @@ int orte_rmaps_base_get_target_nodes(opal_list_t *allocated_nodes, orte_std_cntr
             if (NULL == (node = (orte_node_t*)opal_pointer_array_get_item(orte_node_pool, i))) {
                 continue;
             }
+            /* ignore nodes that are non-usable */
+            if (ORTE_FLAG_TEST(node, ORTE_NODE_NON_USABLE)) {
+                continue;
+            }
             OPAL_LIST_FOREACH_SAFE(nptr, next, &nodes, orte_node_t) {
                 if (0 != strcmp(node->name, nptr->name)) {
                     OPAL_OUTPUT_VERBOSE((10, orte_rmaps_base_framework.framework_output,
@@ -320,6 +324,10 @@ int orte_rmaps_base_get_target_nodes(opal_list_t *allocated_nodes, orte_std_cntr
     }
     for (i=1; i < orte_node_pool->size; i++) {
         if (NULL != (node = (orte_node_t*)opal_pointer_array_get_item(orte_node_pool, i))) {
+            /* ignore nodes that are non-usable */
+            if (ORTE_FLAG_TEST(node, ORTE_NODE_NON_USABLE)) {
+                continue;
+            }
             /* ignore nodes that are marked as do-not-use for this mapping */
             if (ORTE_NODE_STATE_DO_NOT_USE == node->state) {
                 OPAL_OUTPUT_VERBOSE((10, orte_rmaps_base_framework.framework_output,

--- a/orte/orted/orted_main.c
+++ b/orte/orted/orted_main.c
@@ -608,7 +608,7 @@ int orte_daemon(int argc, char *argv[])
         orte_pre_condition_transports(jdata, NULL);
 
         /* register the singleton's nspace with our PMIx server */
-        if (ORTE_SUCCESS != (ret = orte_pmix_server_register_nspace(jdata, false))) {
+        if (ORTE_SUCCESS != (ret = orte_pmix_server_register_nspace(jdata))) {
           ORTE_ERROR_LOG(ret);
           goto DONE;
         }

--- a/orte/orted/pmix/pmix_server.h
+++ b/orte/orted/pmix/pmix_server.h
@@ -12,7 +12,7 @@
  * Copyright (c) 2006-2013 Los Alamos National Security, LLC.
  *                         All rights reserved.
  * Copyright (c) 2010-2011 Cisco Systems, Inc.  All rights reserved.
- * Copyright (c) 2013-2017 Intel, Inc. All rights reserved.
+ * Copyright (c) 2013-2018 Intel, Inc. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -35,7 +35,7 @@ ORTE_DECLSPEC void pmix_server_finalize(void);
 ORTE_DECLSPEC void pmix_server_register_params(void);
 
 
-ORTE_DECLSPEC int orte_pmix_server_register_nspace(orte_job_t *jdata, bool force);
+ORTE_DECLSPEC int orte_pmix_server_register_nspace(orte_job_t *jdata);
 
 END_C_DECLS
 

--- a/orte/orted/pmix/pmix_server_dyn.c
+++ b/orte/orted/pmix/pmix_server_dyn.c
@@ -567,7 +567,7 @@ static void _cnlk(int status, opal_list_t *data, void *cbdata)
         goto release;
     }
     OBJ_DESTRUCT(&buf);
-    if (ORTE_SUCCESS != (rc = orte_pmix_server_register_nspace(jdata, true))) {
+    if (ORTE_SUCCESS != (rc = orte_pmix_server_register_nspace(jdata))) {
         OBJ_RELEASE(jdata);
         goto release;
     }
@@ -644,7 +644,7 @@ static void _cnct(int sd, short args, void *cbdata)
          * registered with the local PMIx server */
         if (!orte_get_attribute(&jdata->attributes, ORTE_JOB_NSPACE_REGISTERED, NULL, OPAL_BOOL)) {
             /* it hasn't been registered yet, so register it now */
-            if (ORTE_SUCCESS != (rc = orte_pmix_server_register_nspace(jdata, true))) {
+            if (ORTE_SUCCESS != (rc = orte_pmix_server_register_nspace(jdata))) {
                 goto release;
             }
         }

--- a/orte/orted/pmix/pmix_server_fence.c
+++ b/orte/orted/pmix/pmix_server_fence.c
@@ -199,7 +199,7 @@ static void dmodex_req(int sd, short args, void *cbdata)
      * any local procs. There is no need to request the data as we already have
      * it - so just register the nspace so the local PMIx server gets it */
     if (ORTE_VPID_WILDCARD == req->target.vpid) {
-        rc = orte_pmix_server_register_nspace(jdata, true);
+        rc = orte_pmix_server_register_nspace(jdata);
         if (ORTE_SUCCESS != rc) {
             goto callback;
         }

--- a/orte/orted/pmix/pmix_server_gen.c
+++ b/orte/orted/pmix/pmix_server_gen.c
@@ -829,14 +829,18 @@ int pmix_server_query_fn(opal_process_name_t *requestor,
 static void _toolconn(int sd, short args, void *cbdata)
 {
     orte_pmix_server_op_caddy_t *cd = (orte_pmix_server_op_caddy_t*)cbdata;
-    orte_job_t *jdata;
+    orte_job_t *jdata = NULL;
     orte_app_context_t *app;
     orte_proc_t *proc;
-    orte_node_t *node;
-    orte_process_name_t tool;
-    int rc;
+    orte_node_t *node, *nptr;
+    char *hostname = NULL;
+    char *appname = NULL;
+    orte_process_name_t tool = {ORTE_JOBID_INVALID, ORTE_VPID_INVALID};
+    int rc, i;
     opal_value_t *val;
-    bool flag;
+    bool flag = false, flag_given = false;;
+    uid_t uid=0;
+    gid_t gid=0;
 
     ORTE_ACQUIRE_OBJECT(cd);
 
@@ -844,109 +848,170 @@ static void _toolconn(int sd, short args, void *cbdata)
                         "%s TOOL CONNECTION PROCESSING",
                         ORTE_NAME_PRINT(ORTE_PROC_MY_NAME));
 
-   /* if we are the HNP, we can directly assign the jobid */
-    if (ORTE_PROC_IS_HNP || ORTE_PROC_IS_MASTER) {
-        jdata = OBJ_NEW(orte_job_t);
-        rc = orte_plm_base_create_jobid(jdata);
-        if (ORTE_SUCCESS != rc) {
-            tool.jobid = ORTE_JOBID_INVALID;
+    /* check for directives */
+    if (NULL != cd->info) {
+        OPAL_LIST_FOREACH(val, cd->info, opal_value_t) {
+            if (0 == strcmp(val->key, OPAL_PMIX_EVENT_SILENT_TERMINATION)) {
+                if (OPAL_UNDEF == val->type || val->data.flag) {
+                    flag = true;
+                }
+                flag_given = true;
+            } else if (0 == strcmp(val->key, OPAL_PMIX_VERSION_INFO)) {
+                /* we ignore this for now */
+            } else if (0 == strcmp(val->key, OPAL_PMIX_USERID)) {
+                uid = val->data.uint32;
+            } else if (0 == strcmp(val->key, OPAL_PMIX_GRPID)) {
+                gid = val->data.uint32;
+            } else if (0 == strcmp(val->key, OPAL_PMIX_JOBID)) {
+                tool.jobid = val->data.name.jobid;
+            } else if (0 == strcmp(val->key, OPAL_PMIX_RANK)) {
+                tool.vpid = val->data.name.vpid;
+            } else if (0 == strcmp(val->key, OPAL_PMIX_HOSTNAME)) {
+                hostname = val->data.string;
+            } else if (0 == strcmp(val->key, OPAL_PMIX_APPNAME)) {
+                appname = val->data.string;
+            }
+        }
+    }
+
+    opal_output_verbose(2, orte_pmix_server_globals.output,
+                        "%s TOOL CONNECTION FROM UID %d GID %d",
+                        ORTE_NAME_PRINT(ORTE_PROC_MY_NAME), uid, gid);
+
+    /* if we are not the HNP or master, and the tool doesn't
+     * already have a name (i.e., we didn't spawn it), then
+     * there is nothing we can currently do.
+     * Eventually, when we switch to nspace instead of an
+     * integer jobid, we'll just locally assign this value */
+    if (ORTE_JOBID_INVALID == tool.jobid ||
+        ORTE_VPID_INVALID == tool.vpid) {
+       /* if we are the HNP, we can directly assign the jobid */
+        if (ORTE_PROC_IS_HNP || ORTE_PROC_IS_MASTER) {
+            jdata = OBJ_NEW(orte_job_t);
+            rc = orte_plm_base_create_jobid(jdata);
+            if (ORTE_SUCCESS != rc) {
+                OBJ_RELEASE(jdata);
+                if (NULL != cd->toolcbfunc) {
+                    cd->toolcbfunc(rc, tool, cd->cbdata);
+                }
+                OBJ_RELEASE(cd);
+                return;
+            }
+            tool.jobid = jdata->jobid;
             tool.vpid = 0;
+        } else {
+            /* we currently do not support connections to non-HNP/master
+             * daemons from tools that were not spawned by a daemon */
             if (NULL != cd->toolcbfunc) {
-                cd->toolcbfunc(rc, tool, cd->cbdata);
+                cd->toolcbfunc(ORTE_ERR_NOT_SUPPORTED, tool, cd->cbdata);
             }
             OBJ_RELEASE(cd);
             return;
         }
-        opal_hash_table_set_value_uint32(orte_job_data, jdata->jobid, jdata);
-        /* setup some required job-level fields in case this
-         * tool calls spawn, or uses some other functions that
-         * need them */
-        /* must create a map for it (even though it has no
-         * info in it) so that the job info will be picked
-         * up in subsequent pidmaps or other daemons won't
-         * know how to route
-         */
-        jdata->map = OBJ_NEW(orte_job_map_t);
+    } else {
+        jdata = OBJ_NEW(orte_job_t);
+        jdata->jobid = tool.jobid;
+    }
 
-        /* setup an app_context for the singleton */
-        app = OBJ_NEW(orte_app_context_t);
+    opal_hash_table_set_value_uint32(orte_job_data, jdata->jobid, jdata);
+    /* setup some required job-level fields in case this
+     * tool calls spawn, or uses some other functions that
+     * need them */
+    /* must create a map for it (even though it has no
+     * info in it) so that the job info will be picked
+     * up in subsequent pidmaps or other daemons won't
+     * know how to route
+     */
+    jdata->map = OBJ_NEW(orte_job_map_t);
+
+    /* setup an app_context for the singleton */
+    app = OBJ_NEW(orte_app_context_t);
+    if (NULL == appname) {
         app->app = strdup("tool");
-        app->num_procs = 1;
-        opal_pointer_array_add(jdata->apps, app);
-        jdata->num_apps = 1;
+    } else {
+        app->app = strdup(appname);
+    }
+    app->num_procs = 1;
+    opal_pointer_array_add(jdata->apps, app);
+    jdata->num_apps = 1;
 
-        /* setup a proc object for the singleton - since we
-         * -must- be the HNP, and therefore we stored our
-         * node on the global node pool, and since the singleton
-         * -must- be on the same node as us, indicate that
-         */
-        proc = OBJ_NEW(orte_proc_t);
-        proc->name.jobid = jdata->jobid;
-        proc->name.vpid = 0;
-        proc->parent = ORTE_PROC_MY_NAME->vpid;
-        ORTE_FLAG_SET(proc, ORTE_PROC_FLAG_ALIVE);
-        proc->state = ORTE_PROC_STATE_RUNNING;
-        proc->app_idx = 0;
-        /* obviously, it is on my node */
+    /* setup a proc object for the singleton - since we
+     * -must- be the HNP, and therefore we stored our
+     * node on the global node pool, and since the singleton
+     * -must- be on the same node as us, indicate that
+     */
+    proc = OBJ_NEW(orte_proc_t);
+    proc->name.jobid = jdata->jobid;
+    proc->name.vpid = tool.vpid;
+    proc->parent = ORTE_PROC_MY_NAME->vpid;
+    ORTE_FLAG_SET(proc, ORTE_PROC_FLAG_ALIVE);
+    proc->state = ORTE_PROC_STATE_RUNNING;
+    proc->app_idx = 0;
+    if (NULL == hostname) {
+        /* it is on my node */
         node = (orte_node_t*)opal_pointer_array_get_item(orte_node_pool, 0);
-        proc->node = node;
-        OBJ_RETAIN(node);  /* keep accounting straight */
-        opal_pointer_array_add(jdata->procs, proc);
-        jdata->num_procs = 1;
-        /* add the node to the job map */
-        OBJ_RETAIN(node);
-        opal_pointer_array_add(jdata->map->nodes, node);
-        jdata->map->num_nodes++;
-        /* and it obviously is on the node - note that
-         * we do _not_ increment the #procs on the node
-         * as the tool doesn't count against the slot
-         * allocation */
-        OBJ_RETAIN(proc);
-        opal_pointer_array_add(node->procs, proc);
-        /* set the trivial */
-        proc->local_rank = 0;
-        proc->node_rank = 0;
-        proc->app_rank = 0;
-        proc->state = ORTE_PROC_STATE_RUNNING;
-        proc->app_idx = 0;
-        ORTE_FLAG_SET(proc, ORTE_PROC_FLAG_LOCAL);
-
-        /* check for directives */
-        if (NULL != cd->info) {
-            OPAL_LIST_FOREACH(val, cd->info, opal_value_t) {
-                if (0 == strcmp(val->key, OPAL_PMIX_EVENT_SILENT_TERMINATION)) {
-                    if (OPAL_UNDEF == val->type || val->data.flag) {
-                        flag = true;
-                        orte_set_attribute(&jdata->attributes, ORTE_JOB_SILENT_TERMINATION,
-                                           ORTE_ATTR_GLOBAL, &flag, OPAL_BOOL);
-                    }
-                }
+    } else {
+        /* we need to locate it */
+        node = NULL;
+        for (i=0; i < orte_node_pool->size; i++) {
+            if (NULL == (nptr = (orte_node_t*)opal_pointer_array_get_item(orte_node_pool, i))) {
+                continue;
+            }
+            if (0 == strcmp(hostname, nptr->name)) {
+                node = nptr;
+                break;
             }
         }
+        if (NULL == node) {
+            /* not in our allocation - which is still okay */
+            node = OBJ_NEW(orte_node_t);
+            node->name = strdup(hostname);
+            ORTE_FLAG_SET(node, ORTE_NODE_NON_USABLE);
+            opal_pointer_array_add(orte_node_pool, node);
+        }
+    }
+    proc->node = node;
+    OBJ_RETAIN(node);  /* keep accounting straight */
+    opal_pointer_array_add(jdata->procs, proc);
+    jdata->num_procs = 1;
+    /* add the node to the job map */
+    OBJ_RETAIN(node);
+    opal_pointer_array_add(jdata->map->nodes, node);
+    jdata->map->num_nodes++;
+    /* and it obviously is on the node - note that
+     * we do _not_ increment the #procs on the node
+     * as the tool doesn't count against the slot
+     * allocation */
+    OBJ_RETAIN(proc);
+    opal_pointer_array_add(node->procs, proc);
+    /* set the trivial */
+    proc->local_rank = 0;
+    proc->node_rank = 0;
+    proc->app_rank = 0;
+    proc->state = ORTE_PROC_STATE_RUNNING;
+    proc->app_idx = 0;
+    /* if it is on my node, mark it as local */
+    nptr = (orte_node_t*)opal_pointer_array_get_item(orte_node_pool, 0);
+    if (node == nptr) {
+        ORTE_FLAG_SET(proc, ORTE_PROC_FLAG_LOCAL);
+    }
+    /* if they indicated a preference for termination, set it */
+    if (flag_given) {
+        orte_set_attribute(&jdata->attributes, ORTE_JOB_SILENT_TERMINATION,
+                           ORTE_ATTR_GLOBAL, &flag, OPAL_BOOL);
+    } else {
+        /* we default to silence */
         flag = true;
         orte_set_attribute(&jdata->attributes, ORTE_JOB_SILENT_TERMINATION,
                            ORTE_ATTR_GLOBAL, &flag, OPAL_BOOL);
-
-        /* pass back the assigned jobid */
-        tool.jobid = jdata->jobid;
-        tool.vpid = 0;
-        if (NULL != cd->toolcbfunc) {
-            cd->toolcbfunc(rc, tool, cd->cbdata);
         }
-        OBJ_RELEASE(cd);
-        return;
-    }
 
-    /* otherwise, we have to send the request to the HNP.
-     * Eventually, when we switch to nspace instead of an
-     * integer jobid, we'll just locally assign this value */
-     tool.jobid = ORTE_JOBID_INVALID;
-     tool.vpid = ORTE_VPID_INVALID;
     if (NULL != cd->toolcbfunc) {
-        cd->toolcbfunc(ORTE_ERR_NOT_SUPPORTED, tool, cd->cbdata);
+        cd->toolcbfunc(rc, tool, cd->cbdata);
     }
     OBJ_RELEASE(cd);
 }
+
 void pmix_tool_connected_fn(opal_list_t *info,
                             opal_pmix_tool_connection_cbfunc_t cbfunc,
                             void *cbdata)

--- a/orte/orted/pmix/pmix_server_register_fns.c
+++ b/orte/orted/pmix/pmix_server_register_fns.c
@@ -54,7 +54,7 @@
 static void mycbfunc(int status, void *cbdata);
 
 /* stuff proc attributes for sending back to a proc */
-int orte_pmix_server_register_nspace(orte_job_t *jdata, bool force)
+int orte_pmix_server_register_nspace(orte_job_t *jdata)
 {
     int rc;
     orte_proc_t *pptr;
@@ -439,7 +439,7 @@ int orte_pmix_server_register_nspace(orte_job_t *jdata, bool force)
             kv = OBJ_NEW(opal_value_t);
             kv->key = strdup(OPAL_PMIX_NODE_RANK);
             kv->type = OPAL_UINT16;
-            kv->data.uint32 = pptr->node_rank;
+            kv->data.uint16 = pptr->node_rank;
             opal_list_append(pmap, &kv->super);
 
             /* node ID */

--- a/orte/util/attr.h
+++ b/orte/util/attr.h
@@ -64,6 +64,7 @@ typedef uint8_t orte_node_flags_t;
 #define ORTE_NODE_FLAG_OVERSUBSCRIBED     0x04   // whether or not this node is oversubscribed
 #define ORTE_NODE_FLAG_MAPPED             0x08   // whether we have been added to the current map
 #define ORTE_NODE_FLAG_SLOTS_GIVEN        0x10   // the number of slots was specified - used only in non-managed environments
+#define ORTE_NODE_NON_USABLE              0x20   // the flag is hosting a tool and is NOT to be used for jobs
 
 
 /*** NODE ATTRIBUTE KEYS - never sent anywhere ***/

--- a/orte/util/proc_info.h
+++ b/orte/util/proc_info.h
@@ -11,7 +11,7 @@
  *                         All rights reserved.
  * Copyright (c) 2011-2012 Los Alamos National Security, LLC.
  *                         All rights reserved.
- * Copyright (c) 2013-2017 Intel, Inc. All rights reserved.
+ * Copyright (c) 2013-2018 Intel, Inc. All rights reserved.
  * Copyright (c) 2017      Cisco Systems, Inc.  All rights reserved
  * $COPYRIGHT$
  *
@@ -58,7 +58,9 @@ typedef uint32_t orte_proc_type_t;
 #define ORTE_PROC_DVM           0x0102   // DVM + daemon
 #define ORTE_PROC_IOF_ENDPT     0x1000
 #define ORTE_PROC_MASTER_ACTUAL 0x4000
-#define ORTE_PROC_MASTER        (ORTE_PROC_MASTER_ACTUAL + ORTE_PROC_HNP)
+#define ORTE_PROC_MASTER        (ORTE_PROC_MASTER_ACTUAL | ORTE_PROC_HNP)
+#define ORTE_PROC_LAUNCHER_ACT  0x8000
+#define ORTE_PROC_LAUNCHER      (ORTE_PROC_LAUNCHER_ACT | ORTE_PROC_TOOL)
 
 #define ORTE_PROC_IS_SINGLETON      (ORTE_PROC_SINGLETON & orte_process_info.proc_type)
 #define ORTE_PROC_IS_DAEMON         (ORTE_PROC_DAEMON & orte_process_info.proc_type)
@@ -70,6 +72,7 @@ typedef uint32_t orte_proc_type_t;
 #define ORTE_PROC_IS_DVM            (ORTE_PROC_DVM & orte_process_info.proc_type)
 #define ORTE_PROC_IS_IOF_ENDPT      (ORTE_PROC_IOF_ENDPT & orte_process_info.proc_type)
 #define ORTE_PROC_IS_MASTER         (ORTE_PROC_MASTER_ACTUAL & orte_process_info.proc_type)
+#define ORTE_PROC_IS_LAUNCHER       (ORTE_PROC_LAUNCHER_ACT & orte_process_info.proc_type)
 
 
 /**


### PR DESCRIPTION
Sync to OMPI master

Ensure that debugger daemons properly connect to their local PMIx server. Ensure that both global and local proctables are returned. Fix debugger release in PMIx_Init. Fix job termination notification. Extend notification to support "affected procs" so that procs can register to receive termination notification from only specific jobs.
    
Allow the launcher to act as a pseudo-server
    
Launchers do not have local clients, but they do need to be able to respond to queries and other requests. So allow them to perform some server-like functions
    
Signed-off-by: Ralph Castain <rhc@open-mpi.org>
